### PR TITLE
Enable some ruff rules for docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ python = "3.8"
 extra-dependencies = [
   # we have to set a version here since cvxpy is not listed as a dependency
   # we use cvxpy-base to avoid installing unnecessary dependencies
-  "cvxpy-base>=1.2.0",
+  "cvxpy-base>=1.1.16",
   # bundled license is expired on older versions of gurobipy
   "gurobipy>=11",
 ]
@@ -137,7 +137,9 @@ ignore = [
   "ANN401",  # Any must be used due to poorly typed libraries and very dynamic return types
   "COM812",  # conflicts with formatter
   "CPY",     # no copyright on each file
-  "D",       # let's decide when documentation is needed
+  "D10",     # let's decide when documentation is needed
+  "D203",    # blank-line-before-class
+  "D213",    # multi-line-summary-second-line
   "DOC201",  # return is not documented in docstring
   "E501",    # comments may exceed line length
   "FIX",     # TODOs are fine

--- a/src/cvxpy_translation/gurobi/interface.py
+++ b/src/cvxpy_translation/gurobi/interface.py
@@ -92,6 +92,7 @@ def fill_model(problem: cp.Problem, model: gp.Model) -> None:
         problem: The CVXPY problem to convert.
         model: The Gurobi model to which constraints and objectives are added.
         variable_map: A mapping from CVXPY variable names to Gurobi variables.
+
     """
     Translater(model).visit(problem)
 

--- a/src/cvxpy_translation/gurobi/translation.py
+++ b/src/cvxpy_translation/gurobi/translation.py
@@ -185,7 +185,9 @@ def add_variable(
 
 
 def _should_reverse_inequality(lower: object, upper: object) -> bool:
-    """When writing an inequality constraint lower <= upper,
+    """Check whether lower <= upper is safe.
+
+    When writing an inequality constraint lower <= upper,
     we get an error if lower is an array and upper is a gurobipy object:
         gurobipy.GurobiError:
             Constraint has no bool value (are you trying "lb <= expr <= ub"?)

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -36,10 +36,10 @@ def test_parameter() -> None:
 
 
 def test_parameter_reshape() -> None:
-    """Parameter.value is not necessarily a numpy/scipy array,
-    so reshaping is not always straightforward.
+    """From https://github.com/jonathanberthias/cvxpy-translation/issues/76.
 
-    See https://github.com/jonathanberthias/cvxpy-translation/issues/76
+    Parameter.value is not necessarily a numpy/scipy array,
+    so reshaping is not always straightforward.
     """
     translater = Translater(gp.Model())
     p = cp.Parameter()


### PR DESCRIPTION
Only the D10x rules are annoying, so enable the rest.

It's really just an excuse to test the deplyment to Test PyPI works :shushing_face: 