### PR TITLE
Enable scalar linear and quadratic test cases for SCIP

### DIFF
--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -144,9 +144,8 @@ def extract_solution_from_model(model: scip.Model, problem: cp.Problem) -> Solut
         dual = get_constraint_dual(model, str(constr.constr_id), constr.shape)
         if dual is None:
             continue
-        if isinstance(problem.objective, cp.Minimize) and (
-            isinstance(constr, Equality)
-            or (isinstance(constr, Inequality) and constr.args[1].is_constant())
+        if isinstance(constr, Equality) or (
+            isinstance(constr, Inequality) and constr.args[1].is_constant()
         ):
             dual *= -1
         dual_vars[constr.constr_id] = dual

--- a/tests/snapshots/scip/all__lp_quadratic13__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic13__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  power(x, 2.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -2 x_1 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ soc_t_1 free
+ soc_t_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x2
+Subject to
+ c1: +1 x2 + [ -1 x * x ] >= +0
+Bounds
+ x free
+ x2 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic14__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic14__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  power(x, 2.0) + 1.0
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -2 x_1 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ soc_t_1 free
+ soc_t_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x2
+Subject to
+ c1: +1 x2 + [ -1 x * x ] >= +1
+Bounds
+ x free
+ x2 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic15__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic15__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  power(x, 2.0) + x
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -2 x_1 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ soc_t_1 free
+ soc_t_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x2
+Subject to
+ c1: +1 x2 -1 x + [ -1 x * x ] >= +0
+Bounds
+ x free
+ x2 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic16__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic16__0.txt
@@ -1,0 +1,39 @@
+CVXPY
+Minimize
+  power(x, 2.0) + power(x, 2.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -2 x_2 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+ c5: +1 soc_t_3 -1 x_1 = +1
+ c6: +1 soc_t_4 -1 x_1 = -1
+ c7: +1 soc_t_5 -2 x_2 = +0
+ c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 -1 soc_t_3 * soc_t_3 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_1 free
+ soc_t_2 free
+ soc_t_4 free
+ soc_t_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x2
+Subject to
+ c1: +1 x2 + [ -2 x * x ] >= +0
+Bounds
+ x free
+ x2 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic17__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic17__0.txt
@@ -1,0 +1,42 @@
+CVXPY
+Minimize
+  power(x, 2.0) + power(y, 2.0)
+Subject To
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -2 x_2 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+ c5: +1 soc_t_3 -1 x_1 = +1
+ c6: +1 soc_t_4 -1 x_1 = -1
+ c7: +1 soc_t_5 -2 x_3 = +0
+ c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 -1 soc_t_3 * soc_t_3 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ soc_t_1 free
+ soc_t_2 free
+ soc_t_4 free
+ soc_t_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 + [ -1 x * x -1 y * y ] >= +0
+Bounds
+ x free
+ y free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic18__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic18__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  2.0 @ power(x, 2.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -2 x_1 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ soc_t_1 free
+ soc_t_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x2
+Subject to
+ c1: +1 x2 + [ -2 x * x ] >= +0
+Bounds
+ x free
+ x2 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic19__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic19__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  power(2.0 @ x, 2.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -4 x_1 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ soc_t_1 free
+ soc_t_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x2
+Subject to
+ c1: +1 x2 + [ -4 x * x ] >= +0
+Bounds
+ x free
+ x2 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic20__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic20__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  power(2.0 @ x, 2.0) + 1.0
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -4 x_1 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ soc_t_1 free
+ soc_t_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x2
+Subject to
+ c1: +1 x2 + [ -4 x * x ] >= +1
+Bounds
+ x free
+ x2 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic21__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic21__0.txt
@@ -1,0 +1,39 @@
+CVXPY
+Minimize
+  power(2.0 @ x, 2.0) + power(x, 2.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -4 x_2 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+ c5: +1 soc_t_3 -1 x_1 = +1
+ c6: +1 soc_t_4 -1 x_1 = -1
+ c7: +1 soc_t_5 -2 x_2 = +0
+ c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 -1 soc_t_3 * soc_t_3 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_1 free
+ soc_t_2 free
+ soc_t_4 free
+ soc_t_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x2
+Subject to
+ c1: +1 x2 + [ -5 x * x ] >= +0
+Bounds
+ x free
+ x2 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic22__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic22__0.txt
@@ -1,0 +1,42 @@
+CVXPY
+Minimize
+  power(2.0 @ x, 2.0) + power(y, 2.0)
+Subject To
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -4 x_2 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+ c5: +1 soc_t_3 -1 x_1 = +1
+ c6: +1 soc_t_4 -1 x_1 = -1
+ c7: +1 soc_t_5 -2 x_3 = +0
+ c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 -1 soc_t_3 * soc_t_3 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ soc_t_1 free
+ soc_t_2 free
+ soc_t_4 free
+ soc_t_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 + [ -4 x * x -1 y * y ] >= +0
+Bounds
+ x free
+ y free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic23__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic23__0.txt
@@ -1,0 +1,35 @@
+CVXPY
+Minimize
+  power(x + y, 2.0)
+Subject To
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -2 x_1 -2 x_2 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_1 free
+ soc_t_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 + [ -1 x * x -2 x * y -1 y * y ] >= +0
+Bounds
+ x free
+ y free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic24__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic24__0.txt
@@ -1,0 +1,35 @@
+CVXPY
+Minimize
+  power(x + -y, 2.0)
+Subject To
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 -1 x_0 = -1
+ c3: +1 soc_t_2 -2 x_1 +2 x_2 = +0
+ c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_1 free
+ soc_t_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 + [ -1 x * x +2 x * y -1 y * y ] >= +0
+Bounds
+ x free
+ y free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_quadratic25__0.txt
+++ b/tests/snapshots/scip/all__lp_quadratic25__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  power(x + -y, 2.0) + x + y
+Subject To
+ 41: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2
+Subject to
+ c1: +1 x_2 = +0
+ c2: +1 soc_t_1 -1 x_0 = +1
+ c3: +1 soc_t_2 -1 x_0 = -1
+ c4: +1 soc_t_3 -2 x_1 +2 x_2 = +0
+ c5: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_1 * soc_t_1 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_2 free
+ soc_t_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 -1 x -1 y + [ -1 x * x +2 x * y -1 y * y ] >= +0
+ 41: +1 y = +0
+Bounds
+ x free
+ y free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear13__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear13__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 5: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= -1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 5: +1 x >= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear14__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear14__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 9: x <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 9: +1 x <= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear15__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear15__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 13: x == 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 x_0 = +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 13: +1 x = +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear16__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear16__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 17: 1.0 <= x
+ 21: x <= 2.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= -1
+ c2: +1 x_0 <= +2
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 17: +1 x >= +1
+ 21: +1 x <= +2
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear17__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear17__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 25: 1.0 <= x
+ 29: x <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= -1
+ c2: +1 x_0 <= +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 25: +1 x >= +1
+ 29: +1 x <= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear18__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear18__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 33: 0.0 <= x
+ 37: x <= 2.0
+ 41: x == 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 x_0 = +1
+ c2: -1 x_0 <= +0
+ c3: +1 x_0 <= +2
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 33: +1 x >= +0
+ 37: +1 x <= +2
+ 41: +1 x = +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear19__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear19__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 45: 1.0 <= x
+ 49: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 45: +1 x >= +1
+ 49: +1 y >= +1
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear20__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear20__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 53: x == 1.0
+ 57: y == 1.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 x_0 = +1
+ c2: +1 x_1 = +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 53: +1 x = +1
+ 57: +1 y = +1
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear21__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear21__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 62: 1.0 <= x + y
+ 66: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 x_1 = +0
+ c2: -1 x_0 -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 62: +1 x +1 y >= +1
+ 66: +1 y = +0
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear22__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear22__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 71: x + y <= 1.0
+ 75: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_1 = +0
+ c2: +1 x_0 +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 71: +1 x +1 y <= +1
+ 75: +1 y = +0
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear23__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear23__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 80: x + y == 1.0
+ 84: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 x_0 +1 x_1 = +1
+ c2: +1 x_1 = +0
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 80: +1 x +1 y = +1
+ 84: +1 y = +0
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear24__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear24__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 89: 1.0 <= 2.0 @ x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -2 x_0 <= -1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 89: +2 x >= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_scalar_linear25__0.txt
+++ b/tests/snapshots/scip/all__lp_scalar_linear25__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 95: 1.0 <= 2.0 @ x + y
+ 99: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 x_1 = +0
+ c2: -2 x_0 -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 95: +2 x +1 y >= +1
+ 99: +1 y = +0
+Bounds
+ x free
+ y free
+End

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -191,9 +191,7 @@ def check_backfill_scip(case: ProblemTestCase) -> None:
     # This is one point where we cannot guarantee that our solution is the same as CVXPY's
     # if the dual values are important
     if our_sol.dual_vars is not None:
-        assert set(our_sol.dual_vars) == set(cp_sol.dual_vars)
-        for key in our_sol.dual_vars:
-            assert our_sol.dual_vars[key] == pytest.approx(cp_sol.dual_vars[key])
+        assert our_sol.dual_vars == pytest.approx(cp_sol.dual_vars)
     assert set(our_sol.attr) >= set(cp_sol.attr)
     # In some cases, iteration count can be negative??
     cp_iters = max(cp_sol.attr.get(s.NUM_ITERS, math.inf), 0)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -5,6 +5,7 @@ import warnings
 from itertools import chain
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Final
 from typing import Generator
 from unittest.mock import patch
 
@@ -28,6 +29,12 @@ if TYPE_CHECKING:
 
     from cvxpy.reductions.solution import Solution
     from pytest_insta.session import SnapshotSession
+
+
+PARAMS: Final = {
+    cp.GUROBI: {gp.GRB.Param.QCPDual: 1},
+    cp.SCIP: {"numerics/feastol": 1e-10, "numerics/dualfeastol": 1e-10},
+}
 
 
 @pytest.fixture(params=all_valid_problems(), ids=lambda case: case.group)
@@ -66,7 +73,9 @@ def test_lp(case: ProblemTestCase, snapshot: SnapshotFixture, tmp_path: Path) ->
     cvxpy_lines = lp_from_cvxpy(problem)
 
     try:
-        generated_model = quiet_solve(problem, case.context.solver)
+        generated_model = quiet_solve(
+            problem, case.context.solver, params=PARAMS[case.context.solver]
+        )
     except cp.SolverError as e:
         # The solver interfaces in cvxpy can't solve some problems
         cvxpy_interface_lines = [str(e)]
@@ -116,7 +125,8 @@ def test_backfill(case: ProblemTestCase) -> None:
 
 def check_backfill_gurobi(case: ProblemTestCase) -> None:
     problem = case.problem
-    cvxpy_translation.gurobi.solve(problem, **{gp.GRB.Param.QCPDual: 1})
+    params = PARAMS[case.context.solver]
+    cvxpy_translation.gurobi.solve(problem, **params)
     our_sol: Solution = problem.solution
     our_model: gp.Model = our_sol.attr[s.EXTRA_STATS]
     assert our_model.Status == gp.GRB.Status.OPTIMAL
@@ -124,7 +134,7 @@ def check_backfill_gurobi(case: ProblemTestCase) -> None:
     assert our_sol.primal_vars
 
     try:
-        quiet_solve(problem, case.context.solver)
+        quiet_solve(problem, case.context.solver, params=params)
     except cp.SolverError:
         # The problem can't be solved through CVXPY, so we can't compare solutions
         return
@@ -156,11 +166,13 @@ def check_backfill_gurobi(case: ProblemTestCase) -> None:
 
 def check_backfill_scip(case: ProblemTestCase) -> None:
     problem = case.problem
+    params = PARAMS[case.context.solver]
     our_model = cvxpy_translation.scip.build_model(problem)
     # Same settings as in cvxpy's SCIP interface
     our_model.setPresolve(scip.SCIP_PARAMSETTING.OFF)
     our_model.setHeuristics(scip.SCIP_PARAMSETTING.OFF)
     our_model.disablePropagation()
+    our_model.setParams(params)
     our_model.optimize()
     cvxpy_translation.scip.backfill_problem(problem, our_model)
     our_sol: Solution = problem.solution
@@ -169,7 +181,7 @@ def check_backfill_scip(case: ProblemTestCase) -> None:
     assert our_sol.primal_vars
 
     try:
-        quiet_solve(problem, case.context.solver)
+        quiet_solve(problem, case.context.solver, params=params)
     except cp.SolverError:
         # The problem can't be solved through CVXPY, so we can't compare solutions
         return
@@ -181,17 +193,12 @@ def check_backfill_scip(case: ProblemTestCase) -> None:
     assert set(our_sol.primal_vars) == set(cp_sol.primal_vars)
     for key in our_sol.primal_vars:
         assert our_sol.primal_vars[key] == pytest.approx(
-            cp_sol.primal_vars[key], rel=5e-4
+            cp_sol.primal_vars[key], abs=1e-5, rel=1e-4
         )
 
-    # Dual values are not available for MIPs
-    # Sometimes, the SCIP model is a MIP even though the CVXPY problem is not,
-    # notably when using genexprs
-    # So we only check the dual values if the model is not a MIP
-    # This is one point where we cannot guarantee that our solution is the same as CVXPY's
-    # if the dual values are important
-    if our_sol.dual_vars is not None:
-        assert our_sol.dual_vars == pytest.approx(cp_sol.dual_vars)
+    assert set(our_sol.dual_vars) == set(cp_sol.dual_vars)
+    for key in our_sol.dual_vars:
+        assert our_sol.dual_vars[key] == pytest.approx(cp_sol.dual_vars[key])
     assert set(our_sol.attr) >= set(cp_sol.attr)
     # In some cases, iteration count can be negative??
     cp_iters = max(cp_sol.attr.get(s.NUM_ITERS, math.inf), 0)
@@ -247,14 +254,16 @@ def lp_from_scip(model: scip.Model, tmp_path: Path) -> list[str]:
     return out_path.read_text().splitlines()[4:]
 
 
-def quiet_solve(problem: cp.Problem, solver: str) -> gp.Model | scip.Model:
+def quiet_solve(
+    problem: cp.Problem, solver: str, params: dict
+) -> gp.Model | scip.Model:
     with warnings.catch_warnings():
         # Some problems are unbounded
         warnings.filterwarnings("ignore", category=UserWarning)
 
         if solver == cp.GUROBI:
             # Gurobi's solve method returns a Model object
-            problem.solve(solver=cp.GUROBI, **{gp.GRB.Param.QCPDual: 1})
+            problem.solve(solver=cp.GUROBI, **params)
             generated_model = problem.solution.attr[s.EXTRA_STATS]
 
         elif solver == cp.SCIP:
@@ -270,7 +279,7 @@ def quiet_solve(problem: cp.Problem, solver: str) -> gp.Model | scip.Model:
                 return old_opt(self, model, *args, **kwargs)
 
             with patch.object(SCIP, "_solve", new=new_solve):
-                problem.solve(solver=cp.SCIP)
+                problem.solve(solver=cp.SCIP, **params)
 
         else:
             msg = f"Unsupported solver: {solver}"

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -132,7 +132,6 @@ def simple_expressions() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(x**2 + y**2))
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @group_cases("scalar_linear")
 def scalar_linear_constraints() -> Generator[cp.Problem]:
     x = cp.Variable(name="x")

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -180,7 +180,6 @@ def matrix_constraints() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(x)), [S @ x + y + 1 == 0, y == 0])
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @group_cases("quadratic")
 def quadratic_expressions() -> Generator[cp.Problem]:
     x = cp.Variable(name="x")


### PR DESCRIPTION
To get better precision in the results, the tolerances had to be reduced on the solver.