### PR TITLE
Fix reshape translation for SCIP

### DIFF
--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -177,14 +177,13 @@ def get_constraint_dual(
 ) -> npt.NDArray[np.float64] | None:
     if shape == ():
         constr = get_constraint_by_name(model, constraint_name)
-        # CVXPY returns an array of shape (1,) for quadratic constraints
-        # and a scalar for linear constraints -__-
-        try:
-            return np.array(model.getDualsolLinear(constr))
-        except Warning:
-            return None
+        return np.array(model.getDualsolLinear(constr))
 
-    return None
+    dual = np.zeros(shape)
+    for idx, subconstr_name in _matrix_to_scip_names(constraint_name, shape):
+        constr = get_constraint_by_name(model, subconstr_name)
+        dual[idx] = model.getDualsolLinear(constr)
+    return dual
 
 
 def get_constraint_by_name(model: scip.Model, name: str) -> scip.Constraint:

--- a/src/cvxpy_translation/scip/translation.py
+++ b/src/cvxpy_translation/scip/translation.py
@@ -561,11 +561,15 @@ class Translater:
             except AttributeError:
                 return np.reshape(x, target_shape)
         expr = self.visit(x)
-        if isinstance(expr, scip.Variable):
-            expr = np.array([expr]).view(scip.MatrixVariable)
-        elif isinstance(expr, scip.Expr):
+        if isinstance(expr, scip.Expr):
+            if target_shape == ():
+                return expr
             expr = np.array([expr]).view(scip.MatrixExpr)
-        elif not isinstance(expr, scip.MatrixVariable):
+        elif target_shape == ():
+            assert isinstance(expr, scip.MatrixExpr)
+            assert _is_scalar(expr)
+            return expr.item()
+        elif not isinstance(expr, scip.MatrixExpr):
             expr_shape = _shape(expr)
             # Force creation of a MatrixVariable even if the shape is scalar
             if expr_shape == ():

--- a/tests/snapshots/scip/all__lp_reshape29__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape29__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 6: reshape(x, (), F) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 6: +1 x <= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_reshape30__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape30__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 11: reshape(x, (1,), F) <= [1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 11_0: +1 x <= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_reshape31__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape31__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 16: reshape(x, (1,), F) <= [1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 16_0: +1 x <= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_reshape32__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape32__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 21: reshape(x + 1.0, (), F) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +0
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 21: +1 x <= +0
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_reshape33__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape33__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 26: reshape(x + 1.0, (1,), F) <= [1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +0
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 26_0: +1 x <= +0
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_reshape34__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape34__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 31: reshape(x + 1.0, (1,), F) <= [1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +0
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 31_0: +1 x <= +0
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_reshape35__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape35__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 36: reshape(x, (1,), F) <= [1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 36_0: +1 x <= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/all__lp_reshape36__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape36__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 6: reshape(x, (), F) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0
+Subject to
+ 6: +1 x_0 <= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/all__lp_reshape37__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape37__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 11: reshape(x + 1.0, (), F) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +0
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0
+Subject to
+ 11: +1 x_0 <= +0
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/all__lp_reshape38__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape38__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 16: reshape(x, (1,), F) <= [1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0
+Subject to
+ c1: +1 x_0 <= +1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0
+Subject to
+ 16_0: +1 x_0 <= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/all__lp_reshape39__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape39__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 7: reshape(x, (2,), F) <= [1. 1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 7_0: +1 x_0 <= +1
+ 7_1: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape40__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape40__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 13: reshape(x, (2,), F) <= [1. 1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 13_0: +1 x_0 <= +1
+ 13_1: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape41__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape41__0.txt
@@ -1,0 +1,31 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 19: reshape(x, (2, 1), F) <= [[1.00]
+ [1.00]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 19_0_0: +1 x_0 <= +1
+ 19_1_0: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape42__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape42__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 25: reshape(x, (1, 2), F) <= [[1. 1.]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 25_0_0: +1 x_0 <= +1
+ 25_0_1: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape43__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape43__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 31: reshape(x + [1. 1.], (2,), F) <= [1. 1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +0
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 31_0: +1 x_0 <= +0
+ 31_1: +1 x_1 <= +0
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape44__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape44__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 37: reshape(x + [1. 1.], (2,), F) <= [1. 1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +0
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 37_0: +1 x_0 <= +0
+ 37_1: +1 x_1 <= +0
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape45__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape45__0.txt
@@ -1,0 +1,31 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 43: reshape(x + [1. 1.], (2, 1), F) <= [[1.00]
+ [1.00]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +0
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 43_0_0: +1 x_0 <= +0
+ 43_1_0: +1 x_1 <= +0
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape46__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape46__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 49: reshape(x + [1. 1.], (1, 2), F) <= [[1. 1.]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +0
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 49_0_0: +1 x_0 <= +0
+ 49_0_1: +1 x_1 <= +0
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape47__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape47__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 55: reshape(x, (2,), F) <= [0. 1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 55_0: +1 x_0 <= +0
+ 55_1: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_reshape48__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape48__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 7: reshape(x, (4,), F) <= [1. 1. 1. 1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+ c3: +1 x_2 <= +1
+ c4: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 7_0: +1 x_0 <= +1
+ 7_1: +1 x_1 <= +1
+ 7_2: +1 x_2 <= +1
+ 7_3: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape49__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape49__0.txt
@@ -1,0 +1,41 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 13: reshape(x, (4, 1), F) <= [[1.00]
+ [1.00]
+ [1.00]
+ [1.00]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+ c3: +1 x_2 <= +1
+ c4: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 13_0_0: +1 x_0 <= +1
+ 13_1_0: +1 x_1 <= +1
+ 13_2_0: +1 x_2 <= +1
+ 13_3_0: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape50__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape50__0.txt
@@ -1,0 +1,39 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 19: reshape(x, (2, 2), F) <= [[1.00 1.00]
+ [1.00 1.00]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+ c3: +1 x_2 <= +1
+ c4: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 19_0_0: +1 x_0 <= +1
+ 19_0_1: +1 x_1 <= +1
+ 19_1_0: +1 x_2 <= +1
+ 19_1_1: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape51__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape51__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 25: reshape(x, (1, 4), F) <= [[1. 1. 1. 1.]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+ c3: +1 x_2 <= +1
+ c4: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 25_0_0: +1 x_0 <= +1
+ 25_0_1: +1 x_1 <= +1
+ 25_0_2: +1 x_2 <= +1
+ 25_0_3: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape52__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape52__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 31: reshape(x + [1. 1. 1. 1.], (4,), F) <= [1. 1. 1. 1.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +0
+ c3: +1 x_2 <= +0
+ c4: +1 x_3 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 31_0: +1 x_0 <= +0
+ 31_1: +1 x_1 <= +0
+ 31_2: +1 x_2 <= +0
+ 31_3: +1 x_3 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape53__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape53__0.txt
@@ -1,0 +1,41 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 37: reshape(x + [1. 1. 1. 1.], (4, 1), F) <= [[1.00]
+ [1.00]
+ [1.00]
+ [1.00]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +0
+ c3: +1 x_2 <= +0
+ c4: +1 x_3 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 37_0_0: +1 x_0 <= +0
+ 37_1_0: +1 x_1 <= +0
+ 37_2_0: +1 x_2 <= +0
+ 37_3_0: +1 x_3 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape54__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape54__0.txt
@@ -1,0 +1,39 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 43: reshape(x + [1. 1. 1. 1.], (2, 2), F) <= [[1.00 1.00]
+ [1.00 1.00]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +0
+ c3: +1 x_2 <= +0
+ c4: +1 x_3 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 43_0_0: +1 x_0 <= +0
+ 43_0_1: +1 x_1 <= +0
+ 43_1_0: +1 x_2 <= +0
+ 43_1_1: +1 x_3 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape55__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape55__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 49: reshape(x + [1. 1. 1. 1.], (1, 4), F) <= [[1. 1. 1. 1.]]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +0
+ c3: +1 x_2 <= +0
+ c4: +1 x_3 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 49_0_0: +1 x_0 <= +0
+ 49_0_1: +1 x_1 <= +0
+ 49_0_2: +1 x_2 <= +0
+ 49_0_3: +1 x_3 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape56__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape56__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 56: reshape(x, (2, 2), F) <= reshape([1. 1. 1. 1.], (2, 2), F)
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +1
+ c2: +1 x_1 <= +1
+ c3: +1 x_2 <= +1
+ c4: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 56_0_0: +1 x_0 <= +1
+ 56_0_1: +1 x_1 <= +1
+ 56_1_0: +1 x_2 <= +1
+ 56_1_1: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/snapshots/scip/all__lp_reshape57__0.txt
+++ b/tests/snapshots/scip/all__lp_reshape57__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 62: reshape(x, (4,), F) <= [0. 1. 2. 3.]
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 <= +0
+ c2: +1 x_1 <= +1
+ c3: +1 x_2 <= +2
+ c4: +1 x_3 <= +3
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ 62_0: +1 x_0 <= +0
+ 62_1: +1 x_1 <= +1
+ 62_2: +1 x_2 <= +2
+ 62_3: +1 x_3 <= +3
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -586,7 +586,6 @@ def sum_axis() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.sum(x, axis=1) >= 1])
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @group_cases("reshape")
 def reshape() -> Generator[cp.Problem]:
     x = cp.Variable(name="x")


### PR DESCRIPTION
It works surprisingly well, though I suspect some corner cases might uncover as more test cases are added.