### PR TITLE
Support sum with axis for SCIP

### DIFF
--- a/tests/snapshots/gurobi/all__lp_sum_axis0__0.txt
+++ b/tests/snapshots/gurobi/all__lp_sum_axis0__0.txt
@@ -1,15 +1,16 @@
 CVXPY
 Minimize
-  Sum(x, None, False)
+  Sum(x @ [[1.00 3.00]
+ [2.00 4.00]], None, False)
 Subject To
- 6: 1.0 <= Sum(x, None, False)
+ 7: 1.0 <= Sum(x, None, False)
 Bounds
  0.0 <= x
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C1 + C2 + C3
+  C0 + 2 C1 + 3 C2 + 4 C3
 Subject To
  R0: - C0 <= 0
  R1: - C1 <= 0
@@ -25,8 +26,8 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  x[0,0] + x[0,1] + x[1,0] + x[1,1]
+  x[0,0] + 3 x[0,1] + 2 x[1,0] + 4 x[1,1]
 Subject To
- 6: x[0,0] + x[0,1] + x[1,0] + x[1,1] >= 1
+ 7: x[0,0] + x[0,1] + x[1,0] + x[1,1] >= 1
 Bounds
 End

--- a/tests/snapshots/gurobi/all__lp_sum_axis1__0.txt
+++ b/tests/snapshots/gurobi/all__lp_sum_axis1__0.txt
@@ -1,6 +1,7 @@
 CVXPY
 Minimize
-  Sum(x, None, False)
+  Sum(x @ [[1.00 3.00]
+ [2.00 4.00]], None, False)
 Subject To
  13: 1.0 <= Sum(x, 0, False)
 Bounds
@@ -9,7 +10,7 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C1 + C2 + C3
+  C0 + 2 C1 + 3 C2 + 4 C3
 Subject To
  R0: - C0 <= 0
  R1: - C1 <= 0
@@ -26,7 +27,7 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  x[0,0] + x[0,1] + x[1,0] + x[1,1]
+  x[0,0] + 3 x[0,1] + 2 x[1,0] + 4 x[1,1]
 Subject To
  13[0]: x[0,0] + x[1,0] >= 1
  13[1]: x[0,1] + x[1,1] >= 1

--- a/tests/snapshots/gurobi/all__lp_sum_axis3__0.txt
+++ b/tests/snapshots/gurobi/all__lp_sum_axis3__0.txt
@@ -3,7 +3,7 @@ Minimize
   Sum(x @ [[1.00 3.00]
  [2.00 4.00]], None, False)
 Subject To
- 19: 1.0 <= Sum(x, 1, False)
+ 25: 1.0 <= Sum(x, -1, False)
 Bounds
  0.0 <= x
 End
@@ -16,8 +16,8 @@ Subject To
  R1: - C1 <= 0
  R2: - C2 <= 0
  R3: - C3 <= 0
- R4: - C0 - C2 <= -1
- R5: - C1 - C3 <= -1
+ R4: - C0 - C1 - C2 - C3 <= -1
+ R5: <= -1
 Bounds
  C0 free
  C1 free
@@ -29,7 +29,7 @@ GUROBI
 Minimize
   x[0,0] + 3 x[0,1] + 2 x[1,0] + 4 x[1,1]
 Subject To
- 19[0]: x[0,0] + x[0,1] >= 1
- 19[1]: x[1,0] + x[1,1] >= 1
+ 25[0]: x[0,0] + x[0,1] >= 1
+ 25[1]: x[1,0] + x[1,1] >= 1
 Bounds
 End

--- a/tests/snapshots/scip/all__lp_sum_axis4__0.txt
+++ b/tests/snapshots/scip/all__lp_sum_axis4__0.txt
@@ -1,0 +1,33 @@
+CVXPY
+Minimize
+  Sum(x @ [[1.00 3.00]
+ [2.00 4.00]], None, False)
+Subject To
+ 7: 1.0 <= Sum(x, None, False)
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +2 x_1 +3 x_2 +4 x_3
+Subject to
+ c1: -1 x_0 <= +0
+ c2: -1 x_1 <= +0
+ c3: -1 x_2 <= +0
+ c4: -1 x_3 <= +0
+ c5: -1 x_0 -1 x_1 -1 x_2 -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0_0 +3 x_0_1 +2 x_1_0 +4 x_1_1
+Subject to
+ 7: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1 >= +1
+Bounds
+End

--- a/tests/snapshots/scip/all__lp_sum_axis5__0.txt
+++ b/tests/snapshots/scip/all__lp_sum_axis5__0.txt
@@ -1,0 +1,35 @@
+CVXPY
+Minimize
+  Sum(x @ [[1.00 3.00]
+ [2.00 4.00]], None, False)
+Subject To
+ 13: 1.0 <= Sum(x, 0, False)
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +2 x_1 +3 x_2 +4 x_3
+Subject to
+ c1: -1 x_0 <= +0
+ c2: -1 x_1 <= +0
+ c3: -1 x_2 <= +0
+ c4: -1 x_3 <= +0
+ c5: -1 x_0 -1 x_1 <= -1
+ c6: -1 x_2 -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0_0 +3 x_0_1 +2 x_1_0 +4 x_1_1
+Subject to
+ 13_0: +1 x_0_0 +1 x_1_0 >= +1
+ 13_1: +1 x_0_1 +1 x_1_1 >= +1
+Bounds
+End

--- a/tests/snapshots/scip/all__lp_sum_axis6__0.txt
+++ b/tests/snapshots/scip/all__lp_sum_axis6__0.txt
@@ -1,0 +1,35 @@
+CVXPY
+Minimize
+  Sum(x @ [[1.00 3.00]
+ [2.00 4.00]], None, False)
+Subject To
+ 19: 1.0 <= Sum(x, 1, False)
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +2 x_1 +3 x_2 +4 x_3
+Subject to
+ c1: -1 x_0 <= +0
+ c2: -1 x_1 <= +0
+ c3: -1 x_2 <= +0
+ c4: -1 x_3 <= +0
+ c5: -1 x_0 -1 x_2 <= -1
+ c6: -1 x_1 -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0_0 +3 x_0_1 +2 x_1_0 +4 x_1_1
+Subject to
+ 19_0: +1 x_0_0 +1 x_0_1 >= +1
+ 19_1: +1 x_1_0 +1 x_1_1 >= +1
+Bounds
+End

--- a/tests/snapshots/scip/all__lp_sum_axis7__0.txt
+++ b/tests/snapshots/scip/all__lp_sum_axis7__0.txt
@@ -1,0 +1,21 @@
+CVXPY
+Minimize
+  Sum(x @ [[1.00 3.00]
+ [2.00 4.00]], None, False)
+Subject To
+ 25: 1.0 <= Sum(x, -1, False)
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+cannot reshape array of size 1 into shape (2,)
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0_0 +3 x_0_1 +2 x_1_0 +4 x_1_1
+Subject to
+ 25_0: +1 x_0_0 +1 x_0_1 >= +1
+ 25_1: +1 x_1_0 +1 x_1_1 >= +1
+Bounds
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -576,14 +576,17 @@ def sum_scalar() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(x + 1)))
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @group_cases("sum_axis")
 def sum_axis() -> Generator[cp.Problem]:
     x = cp.Variable((2, 2), name="x", nonneg=True)
+    obj = cp.sum(cp.multiply(x, np.arange(1, 5).reshape((2, 2), order="F")))
 
-    yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.sum(x, axis=None) >= 1])
-    yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.sum(x, axis=0) >= 1])
-    yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.sum(x, axis=1) >= 1])
+    yield cp.Problem(cp.Minimize(obj), [cp.sum(x, axis=None) >= 1])
+    yield cp.Problem(cp.Minimize(obj), [cp.sum(x, axis=0) >= 1])
+    yield cp.Problem(cp.Minimize(obj), [cp.sum(x, axis=1) >= 1])
+    if CVXPY_VERSION >= (1, 6, 6):
+        # axis=-1 support added in 1.6.0, but it's broken until 1.6.6
+        yield cp.Problem(cp.Minimize(obj), [cp.sum(x, axis=-1) >= 1])
 
 
 @group_cases("reshape")


### PR DESCRIPTION
1. The axis argument does not work on SCIP variables, so the axis sum is implemented manually
2. The tests did not have a unique solution, so I added coefficients for each variable
3. I added a test with a negative index, it turns out CVXPY just recently added support for that