### PR TITLE
Enable SCIP tests for matrix constraints

### DIFF
--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -177,6 +177,9 @@ def get_constraint_dual(
 ) -> npt.NDArray[np.float64] | None:
     if shape == ():
         constr = get_constraint_by_name(model, constraint_name)
+        if constr.getConshdlrName() == "nonlinear":
+            # dual solutions are not available for nonlinear constraints
+            return None
         return np.array(model.getDualsolLinear(constr))
 
     dual = np.zeros(shape)

--- a/tests/snapshots/scip/all__lp_matrix12__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix12__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 7: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 7_0: +1 x_0 >= +1
+ 7_1: +1 x_1 >= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix13__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix13__0.txt
@@ -1,0 +1,35 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 13: 1.0 <= x
+ 18: x <= 2.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: +1 x_0 <= +2
+ c4: +1 x_1 <= +2
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 13_0: +1 x_0 >= +1
+ 13_1: +1 x_1 >= +1
+ 18_0: +1 x_0 <= +2
+ 18_1: +1 x_1 <= +2
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix14__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix14__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 24: x == 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_0 = +1
+ c2: +1 x_1 = +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 24_0: +1 x_0 = +1
+ 24_1: +1 x_1 = +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix15__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix15__0.txt
@@ -1,0 +1,40 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 30: x == 1.0
+ 35: y == 1.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_0 = +1
+ c2: +1 x_1 = +1
+ c3: +1 x_2 = +1
+ c4: +1 x_3 = +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 30_0: +1 x_0 = +1
+ 30_1: +1 x_1 = +1
+ 35_0: +1 y_0 = +1
+ 35_1: +1 y_1 = +1
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+ y_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix16__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix16__0.txt
@@ -1,0 +1,40 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 42: 1.0 <= x + y
+ 47: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_2 = +0
+ c2: +1 x_3 = +0
+ c3: -1 x_0 -1 x_2 <= -1
+ c4: -1 x_1 -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 42_0: +1 x_0 +1 y_0 >= +1
+ 42_1: +1 x_1 +1 y_1 >= +1
+ 47_0: +1 y_0 = +0
+ 47_1: +1 y_1 = +0
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+ y_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix17__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix17__0.txt
@@ -1,0 +1,40 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 56: 0.0 <= x + y + Promote(1.0, (2,))
+ 61: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_2 = +0
+ c2: +1 x_3 = +0
+ c3: -1 x_0 -1 x_2 <= +1
+ c4: -1 x_1 -1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 56_0: +1 x_0 +1 y_0 >= -1
+ 56_1: +1 x_1 +1 y_1 >= -1
+ 61_0: +1 y_0 = +0
+ 61_1: +1 y_1 = +0
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+ y_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix18__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix18__0.txt
@@ -1,0 +1,31 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 68: [[0.00 1.00]
+ [2.00 3.00]] @ x == 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_1 = +1
+ c2: +2 x_0 +3 x_1 = +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 68_0: +1 x_1 = +1
+ 68_1: +2 x_0 +3 x_1 = +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix19__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix19__0.txt
@@ -1,0 +1,41 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 76: [[0.00 1.00]
+ [2.00 3.00]] @ x + y == 1.0
+ 81: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_1 +1 x_2 = +1
+ c2: +2 x_0 +3 x_1 +1 x_3 = +1
+ c3: +1 x_2 = +0
+ c4: +1 x_3 = +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 76_0: +1 x_1 +1 y_0 = +1
+ 76_1: +2 x_0 +3 x_1 +1 y_1 = +1
+ 81_0: +1 y_0 = +0
+ 81_1: +1 y_1 = +0
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+ y_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix20__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix20__0.txt
@@ -1,0 +1,41 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 91: [[0.00 1.00]
+ [2.00 3.00]] @ x + y + Promote(1.0, (2,)) == 0.0
+ 96: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_1 +1 x_2 = -1
+ c2: +2 x_0 +3 x_1 +1 x_3 = -1
+ c3: +1 x_2 = +0
+ c4: +1 x_3 = +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 91_0: +1 x_1 +1 y_0 = -1
+ 91_1: +2 x_0 +3 x_1 +1 y_1 = -1
+ 96_0: +1 y_0 = +0
+ 96_1: +1 y_1 = +0
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+ y_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix21__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix21__0.txt
@@ -1,0 +1,31 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 103: [[np.float64(0.0) np.float64(1.0)]
+ [np.float64(2.0) np.float64(3.0)]] @ x == 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_1 = +1
+ c2: +2 x_0 +3 x_1 = +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 103_0: +1 x_1 = +1
+ 103_1: +2 x_0 +3 x_1 = +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix22__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix22__0.txt
@@ -1,0 +1,41 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 111: [[np.float64(0.0) np.float64(1.0)]
+ [np.float64(2.0) np.float64(3.0)]] @ x + y == 1.0
+ 116: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_1 +1 x_2 = +1
+ c2: +2 x_0 +3 x_1 +1 x_3 = +1
+ c3: +1 x_2 = +0
+ c4: +1 x_3 = +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 111_0: +1 x_1 +1 y_0 = +1
+ 111_1: +2 x_0 +3 x_1 +1 y_1 = +1
+ 116_0: +1 y_0 = +0
+ 116_1: +1 y_1 = +0
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+ y_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix23__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix23__0.txt
@@ -1,0 +1,41 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 126: [[np.float64(0.0) np.float64(1.0)]
+ [np.float64(2.0) np.float64(3.0)]] @ x + y + Promote(1.0, (2,)) == 0.0
+ 131: y == 0.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_1 +1 x_2 = -1
+ c2: +2 x_0 +3 x_1 +1 x_3 = -1
+ c3: +1 x_2 = +0
+ c4: +1 x_3 = +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 126_0: +1 x_1 +1 y_0 = -1
+ 126_1: +2 x_0 +3 x_1 +1 y_1 = -1
+ 131_0: +1 y_0 = +0
+ 131_1: +1 y_1 = +0
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+ y_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix_quadratic10__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix_quadratic10__0.txt
@@ -1,0 +1,37 @@
+CVXPY
+Minimize
+  quad_over_lin([[2.00 0.00]
+ [0.00 2.00]] @ x, 1.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 +1 x_0 = +1
+ c3: +1 soc_t_2 -4 x_1 = +0
+ c4: +1 soc_t_3 -4 x_2 = +0
+ c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_1 free
+ soc_t_2 free
+ soc_t_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 + [ -4 x_0 * x_0 -4 x_1 * x_1 ] >= +0
+Bounds
+ x_0 free
+ x_1 free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_matrix_quadratic11__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix_quadratic11__0.txt
@@ -1,0 +1,37 @@
+CVXPY
+Minimize
+  quad_over_lin([[np.float64(2.0) np.float64(0.0)]
+ [np.float64(0.0) np.float64(2.0)]] @ x, 1.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 +1 x_0 = +1
+ c3: +1 soc_t_2 -4 x_1 = +0
+ c4: +1 soc_t_3 -4 x_2 = +0
+ c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_1 free
+ soc_t_2 free
+ soc_t_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 + [ -4 x_0 * x_0 -4 x_1 * x_1 ] >= +0
+Bounds
+ x_0 free
+ x_1 free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_matrix_quadratic6__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix_quadratic6__0.txt
@@ -1,0 +1,36 @@
+CVXPY
+Minimize
+  quad_over_lin(x, 1.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 +1 x_0 = +1
+ c3: +1 soc_t_2 -2 x_1 = +0
+ c4: +1 soc_t_3 -2 x_2 = +0
+ c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_1 free
+ soc_t_2 free
+ soc_t_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 + [ -1 x_0 * x_0 -1 x_1 * x_1 ] >= +0
+Bounds
+ x_0 free
+ x_1 free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_matrix_quadratic7__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix_quadratic7__0.txt
@@ -1,0 +1,36 @@
+CVXPY
+Minimize
+  quad_over_lin(x + Promote(-1.0, (2,)), 1.0)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 soc_t_0 -1 x_0 = +1
+ c2: +1 soc_t_1 +1 x_0 = +1
+ c3: +1 soc_t_2 -2 x_1 = -2
+ c4: +1 soc_t_3 -2 x_2 = -2
+ c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_1 free
+ soc_t_2 free
+ soc_t_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 +2 x_0 +2 x_1 + [ -1 x_0 * x_0 -1 x_1 * x_1 ] >= +2
+Bounds
+ x_0 free
+ x_1 free
+ x3 free
+End

--- a/tests/snapshots/scip/all__lp_matrix_quadratic8__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix_quadratic8__0.txt
@@ -1,0 +1,37 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 11: quad_over_lin(x, 1.0) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_2 <= +1
+ c2: +1 soc_t_1 -1 x_2 = +1
+ c3: +1 soc_t_2 +1 x_2 = +1
+ c4: +1 soc_t_3 -2 x_0 = +0
+ c5: +1 soc_t_4 -2 x_1 = +0
+ c6: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 -1 soc_t_1 * soc_t_1 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ soc_t_2 free
+ soc_t_3 free
+ soc_t_4 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 11: + [ +1 x_0 * x_0 +1 x_1 * x_1 ] <= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/all__lp_matrix_quadratic9__0.txt
+++ b/tests/snapshots/scip/all__lp_matrix_quadratic9__0.txt
@@ -1,0 +1,48 @@
+CVXPY
+Minimize
+  quad_over_lin(x, 1.0)
+Subject To
+ 17: quad_over_lin(x, 1.0) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: +1 x_3 <= +1
+ c2: +1 soc_t_1 -1 x_0 = +1
+ c3: +1 soc_t_2 +1 x_0 = +1
+ c4: +1 soc_t_3 -2 x_1 = +0
+ c5: +1 soc_t_4 -2 x_2 = +0
+ c6: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 -1 soc_t_1 * soc_t_1 ] <= +0
+ c7: +1 soc_t_5 -1 x_3 = +1
+ c8: +1 soc_t_6 +1 x_3 = +1
+ c9: +1 soc_t_7 -2 x_1 = +0
+ c10: +1 soc_t_8 -2 x_2 = +0
+ c11: + [ +1 soc_t_6 * soc_t_6 +1 soc_t_7 * soc_t_7 +1 soc_t_8 * soc_t_8 -1 soc_t_5 * soc_t_5 ] <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ soc_t_2 free
+ soc_t_3 free
+ soc_t_4 free
+ soc_t_6 free
+ soc_t_7 free
+ soc_t_8 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x3
+Subject to
+ c1: +1 x3 + [ -1 x_0 * x_0 -1 x_1 * x_1 ] >= +0
+ 17: + [ +1 x_0 * x_0 +1 x_1 * x_1 ] <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x3 free
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -156,7 +156,6 @@ def scalar_linear_constraints() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(x), [2 * x + y >= 1, y == 0])
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @group_cases("matrix")
 def matrix_constraints() -> Generator[cp.Problem]:
     x = cp.Variable(2, name="x")
@@ -200,7 +199,6 @@ def quadratic_expressions() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize((x - y) ** 2 + x + y), [y == 0])
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @group_cases("matrix_quadratic")
 def matrix_quadratic_expressions() -> Generator[cp.Problem]:
     x = cp.Variable(2, name="x")


### PR DESCRIPTION
The dual computation in CVXPY seems fishy. I don't know if it's only for nonlinear constraints though so far it's the only case where I found a discrepancy.