### PR TITLE
Support h- and v-stack with SCIP

### DIFF
--- a/src/cvxpy_translation/scip/translation.py
+++ b/src/cvxpy_translation/scip/translation.py
@@ -381,7 +381,9 @@ class Translater:
         return var
 
     def visit_Hstack(self, node: Hstack) -> Any:
-        return self._stack(node, axis=1, name="hstack")
+        args = node.args
+        exprs = [self.visit(arg) for arg in args]
+        return np.hstack(exprs)
 
     def visit_index(self, node: index) -> Any:
         return self.visit(node.args[0])[node.key]
@@ -532,9 +534,11 @@ class Translater:
 
     def visit_QuadForm(self, node: cp.QuadForm) -> scip.Expr:
         vec, psd_mat = node.args
-        vec = self.visit(vec)
-        psd_mat = self.visit(psd_mat)
-        quad = vec @ psd_mat @ vec.T
+        vec_expr = self.visit(vec)
+        psd_mat_expr = self.visit(psd_mat)
+        quad = vec_expr @ psd_mat_expr @ vec_expr.T
+        if isinstance(quad, scip.Expr):
+            return quad
         # The result is a scalar wrapped in a MatrixExpr
         return quad.item()
 
@@ -603,4 +607,6 @@ class Translater:
         return self.vars[var.id]
 
     def visit_Vstack(self, node: Vstack) -> Any:
-        return self._stack(node, axis=0, name="vstack")
+        args = node.args
+        exprs = [self.visit(arg) for arg in args]
+        return np.vstack(exprs)

--- a/tests/snapshots/scip/lp__hstack_00.txt
+++ b/tests/snapshots/scip/lp__hstack_00.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(x, (1,), F)), None, False)
+Subject To
+ 8: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= -1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 8: +1 x >= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/lp__hstack_01.txt
+++ b/tests/snapshots/scip/lp__hstack_01.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(x, (1,), F), reshape(y, (1,), F), reshape(1.0, (1,), F)), None, False)
+Subject To
+ 17: 1.0 <= x
+ 21: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x +1 y +1
+Subject to
+ 17: +1 x >= +1
+ 21: +1 y >= +1
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/lp__hstack_02.txt
+++ b/tests/snapshots/scip/lp__hstack_02.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(2.0 @ x, (1,), F)), None, False)
+Subject To
+ 29: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0
+Subject to
+ c1: -1 x_0 <= -1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x
+Subject to
+ 29: +1 x >= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/lp__hstack_03.txt
+++ b/tests/snapshots/scip/lp__hstack_03.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(2.0 @ x, (1,), F), reshape(3.0 @ y, (1,), F), reshape(1.0, (1,), F)), None, False)
+Subject To
+ 40: 1.0 <= x
+ 44: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +3 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x +3 y +1
+Subject to
+ 40: +1 x >= +1
+ 44: +1 y >= +1
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/lp__hstack_04.txt
+++ b/tests/snapshots/scip/lp__hstack_04.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Hstack(x), None, False)
+Subject To
+ 7: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= -1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0
+Subject to
+ 7_0: +1 x_0 >= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/lp__hstack_05.txt
+++ b/tests/snapshots/scip/lp__hstack_05.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  Sum(Hstack(x, y, reshape(1.0, (1,), F)), None, False)
+Subject To
+ 14: 1.0 <= x
+ 18: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 y_0 +1
+Subject to
+ 14_0: +1 x_0 >= +1
+ 18_0: +1 y_0 >= +1
+Bounds
+ x_0 free
+ y_0 free
+End

--- a/tests/snapshots/scip/lp__hstack_06.txt
+++ b/tests/snapshots/scip/lp__hstack_06.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Hstack(2.0 @ x), None, False)
+Subject To
+ 25: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0
+Subject to
+ c1: -1 x_0 <= -1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0
+Subject to
+ 25_0: +1 x_0 >= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/lp__hstack_07.txt
+++ b/tests/snapshots/scip/lp__hstack_07.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  Sum(Hstack(2.0 @ x, 3.0 @ y, reshape(1.0, (1,), F)), None, False)
+Subject To
+ 34: 1.0 <= x
+ 38: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +3 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0 +3 y_0 +1
+Subject to
+ 34_0: +1 x_0 >= +1
+ 38_0: +1 y_0 >= +1
+Bounds
+ x_0 free
+ y_0 free
+End

--- a/tests/snapshots/scip/lp__hstack_08.txt
+++ b/tests/snapshots/scip/lp__hstack_08.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(Hstack(x), None, False)
+Subject To
+ 7: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 7_0: +1 x_0 >= +1
+ 7_1: +1 x_1 >= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/lp__hstack_09.txt
+++ b/tests/snapshots/scip/lp__hstack_09.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(Hstack(Promote(2.0, (2,)) @ x), None, False)
+Subject To
+ 16: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +2 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0 +2 x_1
+Subject to
+ 16_0: +1 x_0 >= +1
+ 16_1: +1 x_1 >= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/lp__hstack_10.txt
+++ b/tests/snapshots/scip/lp__hstack_10.txt
@@ -1,0 +1,36 @@
+CVXPY
+Minimize
+  Sum(Hstack(x, y, reshape(1.0, (1,), F)), None, False)
+Subject To
+ 24: 1.0 <= x
+ 28: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 y_0 +1
+Subject to
+ 24_0: +1 x_0 >= +1
+ 24_1: +1 x_1 >= +1
+ 28_0: +1 y_0 >= +1
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+End

--- a/tests/snapshots/scip/lp__hstack_11.txt
+++ b/tests/snapshots/scip/lp__hstack_11.txt
@@ -1,0 +1,36 @@
+CVXPY
+Minimize
+  Sum(Hstack(Promote(2.0, (2,)) @ x, 3.0 @ y, reshape(1.0, (1,), F)), None, False)
+Subject To
+ 39: 1.0 <= x
+ 43: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +2 x_1 +3 x_2
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0 +2 x_1 +3 y_0 +1
+Subject to
+ 39_0: +1 x_0 >= +1
+ 39_1: +1 x_1 >= +1
+ 43_0: +1 y_0 >= +1
+Bounds
+ x_0 free
+ x_1 free
+ y_0 free
+End

--- a/tests/snapshots/scip/lp__hstack_12.txt
+++ b/tests/snapshots/scip/lp__hstack_12.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Hstack(x), None, False)
+Subject To
+ 8: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1
+Subject to
+ 8_0_0: +1 x_0_0 >= +1
+ 8_0_1: +1 x_0_1 >= +1
+ 8_1_0: +1 x_1_0 >= +1
+ 8_1_1: +1 x_1_1 >= +1
+Bounds
+ x_0_0 free
+ x_0_1 free
+ x_1_0 free
+ x_1_1 free
+End

--- a/tests/snapshots/scip/lp__hstack_13.txt
+++ b/tests/snapshots/scip/lp__hstack_13.txt
@@ -1,0 +1,49 @@
+CVXPY
+Minimize
+  Sum(Hstack(x, y, [[0.00 1.00]
+ [2.00 3.00]]), None, False)
+Subject To
+ 15: 1.0 <= x
+ 20: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3 +1 x_4 +1 x_5
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+ c5: -1 x_4 <= -1
+ c6: -1 x_5 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1 +1 y_0_0 +1 y_1_0 +6
+Subject to
+ 15_0_0: +1 x_0_0 >= +1
+ 15_0_1: +1 x_0_1 >= +1
+ 15_1_0: +1 x_1_0 >= +1
+ 15_1_1: +1 x_1_1 >= +1
+ 20_0_0: +1 y_0_0 >= +1
+ 20_1_0: +1 y_1_0 >= +1
+Bounds
+ x_0_0 free
+ x_0_1 free
+ x_1_0 free
+ x_1_1 free
+ y_0_0 free
+ y_1_0 free
+End

--- a/tests/snapshots/scip/lp__hstack_14.txt
+++ b/tests/snapshots/scip/lp__hstack_14.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Hstack(Promote(2.0, (2, 2)) @ x), None, False)
+Subject To
+ 29: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +2 x_1 +2 x_2 +2 x_3
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0_0 +2 x_0_1 +2 x_1_0 +2 x_1_1
+Subject to
+ 29_0_0: +1 x_0_0 >= +1
+ 29_0_1: +1 x_0_1 >= +1
+ 29_1_0: +1 x_1_0 >= +1
+ 29_1_1: +1 x_1_1 >= +1
+Bounds
+ x_0_0 free
+ x_0_1 free
+ x_1_0 free
+ x_1_1 free
+End

--- a/tests/snapshots/scip/lp__hstack_15.txt
+++ b/tests/snapshots/scip/lp__hstack_15.txt
@@ -1,0 +1,49 @@
+CVXPY
+Minimize
+  Sum(Hstack(Promote(2.0, (2, 2)) @ x, Promote(3.0, (2, 1)) @ y, [[0.00 1.00]
+ [2.00 3.00]]), None, False)
+Subject To
+ 40: 1.0 <= x
+ 45: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +2 x_1 +2 x_2 +2 x_3 +3 x_4 +3 x_5
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+ c5: -1 x_4 <= -1
+ c6: -1 x_5 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0_0 +2 x_0_1 +2 x_1_0 +2 x_1_1 +3 y_0_0 +3 y_1_0 +6
+Subject to
+ 40_0_0: +1 x_0_0 >= +1
+ 40_0_1: +1 x_0_1 >= +1
+ 40_1_0: +1 x_1_0 >= +1
+ 40_1_1: +1 x_1_1 >= +1
+ 45_0_0: +1 y_0_0 >= +1
+ 45_1_0: +1 y_1_0 >= +1
+Bounds
+ x_0_0 free
+ x_0_1 free
+ x_1_0 free
+ x_1_1 free
+ y_0_0 free
+ y_1_0 free
+End

--- a/tests/snapshots/scip/lp__quad_form_stack_00.txt
+++ b/tests/snapshots/scip/lp__quad_form_stack_00.txt
@@ -34,20 +34,11 @@ End
 ----------------------------------------
 SCIP
 Minimize
- Obj: +1 x7
+ Obj: +1 x3
 Subject to
- c1: +1 hstack_1_0 -1 x_0 = +0
- c2: +1 hstack_1_1 -1 x_1 = +0
- c3: +1 hstack_1_2 = +1
- c4: +1 hstack_1_3 = +2
- c5: +1 x7 + [ -1 hstack_1_0 * hstack_1_0 -1 hstack_1_1 * hstack_1_1 -1 hstack_1_2 * hstack_1_2 -1 hstack_1_3 * hstack_1_3
- ] >= +0
+ c1: +1 x3 + [ -1 x_0 * x_0 -1 x_1 * x_1 ] >= +5
 Bounds
- hstack_1_0 free
- hstack_1_1 free
- hstack_1_2 free
- hstack_1_3 free
  x_0 free
  x_1 free
- x7 free
+ x3 free
 End

--- a/tests/snapshots/scip/lp__vstack_00.txt
+++ b/tests/snapshots/scip/lp__vstack_00.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Vstack(x), None, False)
+Subject To
+ 7: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= -1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0
+Subject to
+ 7_0: +1 x_0 >= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/lp__vstack_01.txt
+++ b/tests/snapshots/scip/lp__vstack_01.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  Sum(Vstack(x, y, 1.0), None, False)
+Subject To
+ 13: 1.0 <= x
+ 17: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 y_0 +1
+Subject to
+ 13_0: +1 x_0 >= +1
+ 17_0: +1 y_0 >= +1
+Bounds
+ x_0 free
+ y_0 free
+End

--- a/tests/snapshots/scip/lp__vstack_02.txt
+++ b/tests/snapshots/scip/lp__vstack_02.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Vstack(2.0 @ x), None, False)
+Subject To
+ 24: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0
+Subject to
+ c1: -1 x_0 <= -1
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0
+Subject to
+ 24_0: +1 x_0 >= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/lp__vstack_03.txt
+++ b/tests/snapshots/scip/lp__vstack_03.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  Sum(Vstack(2.0 @ x, 3.0 @ y, 1.0), None, False)
+Subject To
+ 32: 1.0 <= x
+ 36: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +3 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0 +3 y_0 +1
+Subject to
+ 32_0: +1 x_0 >= +1
+ 36_0: +1 y_0 >= +1
+Bounds
+ x_0 free
+ y_0 free
+End

--- a/tests/snapshots/scip/lp__vstack_04.txt
+++ b/tests/snapshots/scip/lp__vstack_04.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(Vstack(x), None, False)
+Subject To
+ 7: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ 7_0: +1 x_0 >= +1
+ 7_1: +1 x_1 >= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/lp__vstack_05.txt
+++ b/tests/snapshots/scip/lp__vstack_05.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(Vstack(Promote(2.0, (2,)) @ x), None, False)
+Subject To
+ 16: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +2 x_1
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0 +2 x_1
+Subject to
+ 16_0: +1 x_0 >= +1
+ 16_1: +1 x_1 >= +1
+Bounds
+ x_0 free
+ x_1 free
+End

--- a/tests/snapshots/scip/lp__vstack_06.txt
+++ b/tests/snapshots/scip/lp__vstack_06.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Vstack(x), None, False)
+Subject To
+ 8: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1
+Subject to
+ 8_0_0: +1 x_0_0 >= +1
+ 8_0_1: +1 x_0_1 >= +1
+ 8_1_0: +1 x_1_0 >= +1
+ 8_1_1: +1 x_1_1 >= +1
+Bounds
+ x_0_0 free
+ x_0_1 free
+ x_1_0 free
+ x_1_1 free
+End

--- a/tests/snapshots/scip/lp__vstack_07.txt
+++ b/tests/snapshots/scip/lp__vstack_07.txt
@@ -1,0 +1,49 @@
+CVXPY
+Minimize
+  Sum(Vstack(x, y, [[0.00 1.00]
+ [2.00 3.00]]), None, False)
+Subject To
+ 15: 1.0 <= x
+ 20: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3 +1 x_4 +1 x_5
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+ c5: -1 x_4 <= -1
+ c6: -1 x_5 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1 +1 y_0_0 +1 y_0_1 +6
+Subject to
+ 15_0_0: +1 x_0_0 >= +1
+ 15_0_1: +1 x_0_1 >= +1
+ 15_1_0: +1 x_1_0 >= +1
+ 15_1_1: +1 x_1_1 >= +1
+ 20_0_0: +1 y_0_0 >= +1
+ 20_0_1: +1 y_0_1 >= +1
+Bounds
+ x_0_0 free
+ x_0_1 free
+ x_1_0 free
+ x_1_1 free
+ y_0_0 free
+ y_0_1 free
+End

--- a/tests/snapshots/scip/lp__vstack_08.txt
+++ b/tests/snapshots/scip/lp__vstack_08.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Vstack(Promote(2.0, (2, 2)) @ x), None, False)
+Subject To
+ 29: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +2 x_1 +2 x_2 +2 x_3
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0_0 +2 x_0_1 +2 x_1_0 +2 x_1_1
+Subject to
+ 29_0_0: +1 x_0_0 >= +1
+ 29_0_1: +1 x_0_1 >= +1
+ 29_1_0: +1 x_1_0 >= +1
+ 29_1_1: +1 x_1_1 >= +1
+Bounds
+ x_0_0 free
+ x_0_1 free
+ x_1_0 free
+ x_1_1 free
+End

--- a/tests/snapshots/scip/lp__vstack_09.txt
+++ b/tests/snapshots/scip/lp__vstack_09.txt
@@ -1,0 +1,49 @@
+CVXPY
+Minimize
+  Sum(Vstack(Promote(2.0, (2, 2)) @ x, Promote(3.0, (1, 2)) @ y, [[0.00 1.00]
+ [2.00 3.00]]), None, False)
+Subject To
+ 40: 1.0 <= x
+ 45: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +2 x_0 +2 x_1 +2 x_2 +2 x_3 +3 x_4 +3 x_5
+Subject to
+ c1: -1 x_0 <= -1
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+ c5: -1 x_4 <= -1
+ c6: -1 x_5 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +2 x_0_0 +2 x_0_1 +2 x_1_0 +2 x_1_1 +3 y_0_0 +3 y_0_1 +6
+Subject to
+ 40_0_0: +1 x_0_0 >= +1
+ 40_0_1: +1 x_0_1 >= +1
+ 40_1_0: +1 x_1_0 >= +1
+ 40_1_1: +1 x_1_1 >= +1
+ 45_0_0: +1 y_0_0 >= +1
+ 45_0_1: +1 y_0_1 >= +1
+Bounds
+ x_0_0 free
+ x_0_1 free
+ x_1_0 free
+ x_1_1 free
+ y_0_0 free
+ y_0_1 free
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -736,7 +736,6 @@ def _stack(stack_name: Literal["vstack", "hstack"]) -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(stack([2 * x, 3 * y, A]))), [x >= 1, y >= 1])
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @skipif(
     lambda case: case.context.solver == cp.GUROBI and GUROBI_MAJOR < 11,
     reason="requires Gurobi 11+",
@@ -746,7 +745,6 @@ def vstack() -> Generator[cp.Problem]:
     yield from _stack("vstack")
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @skipif(
     lambda case: case.context.solver == cp.GUROBI and GUROBI_MAJOR < 11,
     reason="requires Gurobi 11+",


### PR DESCRIPTION
Since the SCIP matrix API just uses NumPy arrays, it is really easy. Though the result of the stack is not a SCIP object, it's a plain array. It doesn't seem to cause issues when computing, but there might be some edge cases where it fails?
Oh and this greatly improved the `quad_form_stack` test case as we don't need the auxiliary variable anymore :tada: