### PR TITLE
Support cp.min and cp.max with SCIP

### DIFF
--- a/tests/snapshots/scip/lp__genexpr_min_max_00.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_00.txt
@@ -1,0 +1,28 @@
+CVXPY
+Maximize
+  min(x, None, False)
+Subject To
+ 6: x <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 -1 x_1 <= +0
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x
+Subject to
+ 6: +1 x <= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_01.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_01.txt
@@ -1,0 +1,28 @@
+CVXPY
+Maximize
+  min(x, None, False) + 1.0
+Subject To
+ 12: x <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 -1 x_1 <= +0
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x +1
+Subject to
+ 12: +1 x <= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_02.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_02.txt
@@ -1,0 +1,36 @@
+CVXPY
+Maximize
+  min(x, None, False) + min(y, None, False)
+Subject To
+ 19: x <= 1.0
+ 23: y <= 1.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 -1 x_2 <= +0
+ c2: -1 x_1 -1 x_3 <= +0
+ c3: +1 x_2 <= +1
+ c4: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x +1 y
+Subject to
+ 19: +1 x <= +1
+ 23: +1 y <= +1
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_03.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_03.txt
@@ -1,0 +1,34 @@
+CVXPY
+Maximize
+  min(x + y, None, False)
+Subject To
+ 29: x <= 1.0
+ 33: y <= 1.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 -1 x_1 -1 x_2 <= +0
+ c2: +1 x_1 <= +1
+ c3: +1 x_2 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x +1 y
+Subject to
+ 29: +1 x <= +1
+ 33: +1 y <= +1
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_04.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_04.txt
@@ -1,0 +1,28 @@
+CVXPY
+Minimize
+  max(x, None, False)
+Subject To
+ 4: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 +1 x_1 <= +0
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x
+Subject to
+ 4: +1 x >= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_05.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_05.txt
@@ -1,0 +1,28 @@
+CVXPY
+Minimize
+  max(x, None, False) + 1.0
+Subject To
+ 10: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 +1 x_1 <= +0
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x +1
+Subject to
+ 10: +1 x >= +1
+Bounds
+ x free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_06.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_06.txt
@@ -1,0 +1,36 @@
+CVXPY
+Minimize
+  max(x, None, False) + max(y, None, False)
+Subject To
+ 17: 1.0 <= x
+ 21: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 +1 x_2 <= +0
+ c2: -1 x_1 +1 x_3 <= +0
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x +1 y
+Subject to
+ 17: +1 x >= +1
+ 21: +1 y >= +1
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_07.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_07.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  max(x + y, None, False)
+Subject To
+ 27: 1.0 <= x
+ 31: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 +1 x_1 +1 x_2 <= +0
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x +1 y
+Subject to
+ 27: +1 x >= +1
+ 31: +1 y >= +1
+Bounds
+ x free
+ y free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_08.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_08.txt
@@ -1,0 +1,28 @@
+CVXPY
+Maximize
+  min(x, None, False)
+Subject To
+ 6: x <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 -1 x_1 <= +0
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0
+Subject to
+ 6_0: +1 x_0 <= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_09.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_09.txt
@@ -1,0 +1,28 @@
+CVXPY
+Maximize
+  min(x, None, False) + 1.0
+Subject To
+ 12: x <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 -1 x_1 <= +0
+ c2: +1 x_1 <= +1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1
+Subject to
+ 12_0: +1 x_0 <= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_10.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_10.txt
@@ -1,0 +1,36 @@
+CVXPY
+Maximize
+  min(x, None, False) + min(y, None, False)
+Subject To
+ 19: x <= 1.0
+ 23: y <= 1.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 -1 x_2 <= +0
+ c2: -1 x_1 -1 x_3 <= +0
+ c3: +1 x_2 <= +1
+ c4: +1 x_3 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 y
+Subject to
+ 19_0: +1 x_0 <= +1
+ 23: +1 y <= +1
+Bounds
+ x_0 free
+ y free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_11.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_11.txt
@@ -1,0 +1,34 @@
+CVXPY
+Maximize
+  min(x + y, None, False)
+Subject To
+ 29: x <= 1.0
+ 33: y <= 1.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 -1 x_1 -1 x_2 <= +0
+ c2: +1 x_1 <= +1
+ c3: +1 x_2 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 x_0 +1 y
+Subject to
+ 29_0: +1 x_0 <= +1
+ 33: +1 y <= +1
+Bounds
+ x_0 free
+ y free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_12.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_12.txt
@@ -1,0 +1,28 @@
+CVXPY
+Minimize
+  max(x, None, False)
+Subject To
+ 4: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 +1 x_1 <= +0
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0
+Subject to
+ 4_0: +1 x_0 >= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_13.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_13.txt
@@ -1,0 +1,28 @@
+CVXPY
+Minimize
+  max(x, None, False) + 1.0
+Subject To
+ 10: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 +1 x_1 <= +0
+ c2: -1 x_1 <= -1
+Bounds
+ x_0 free
+ x_1 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1
+Subject to
+ 10_0: +1 x_0 >= +1
+Bounds
+ x_0 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_14.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_14.txt
@@ -1,0 +1,36 @@
+CVXPY
+Minimize
+  max(x, None, False) + max(y, None, False)
+Subject To
+ 17: 1.0 <= x
+ 21: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 +1 x_2 <= +0
+ c2: -1 x_1 +1 x_3 <= +0
+ c3: -1 x_2 <= -1
+ c4: -1 x_3 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 y
+Subject to
+ 17_0: +1 x_0 >= +1
+ 21: +1 y >= +1
+Bounds
+ x_0 free
+ y free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_15.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_15.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  max(x + y, None, False)
+Subject To
+ 27: 1.0 <= x
+ 31: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 +1 x_1 +1 x_2 <= +0
+ c2: -1 x_1 <= -1
+ c3: -1 x_2 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x_0 +1 y
+Subject to
+ 27_0: +1 x_0 >= +1
+ 31: +1 y >= +1
+Bounds
+ x_0 free
+ y free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_16.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_16.txt
@@ -1,0 +1,36 @@
+CVXPY
+Maximize
+  min(X, None, False)
+Subject To
+ 7: X <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 -1 x_1 <= +0
+ c2: -1 x_0 -1 x_2 <= +0
+ c3: +1 x_1 <= +1
+ c4: +1 x_2 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 min_1
+Subject to
+ min_1_0: +1 X_0 -1 min_1 >= +0
+ min_1_1: +1 X_1 -1 min_1 >= +0
+ 7_0: +1 X_0 <= +1
+ 7_1: +1 X_1 <= +1
+Bounds
+ X_0 free
+ X_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_17.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_17.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 13: 1.0 <= min(X, None, False)
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 -1 x_2 <= +0
+ c2: -1 x_1 -1 x_2 <= +0
+ c3: +1 x_2 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ min_1_0: +1 X_0 -1 min_1 >= +0
+ min_1_1: +1 X_1 -1 min_1 >= +0
+ 13: +1 min_1 >= +1
+Bounds
+ X_0 free
+ X_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_18.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_18.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 20: 1.0 <= min(X, None, False) + 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 -1 x_2 <= +0
+ c2: -1 x_1 -1 x_2 <= +0
+ c3: +1 x_2 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ min_1_0: +1 X_0 -1 min_1 >= +0
+ min_1_1: +1 X_1 -1 min_1 >= +0
+ 20: +1 min_1 >= +0
+Bounds
+ X_0 free
+ X_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_19.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_19.txt
@@ -1,0 +1,50 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 28: 1.0 <= min(X, None, False) + min(Y, None, False)
+ 33: Y == 1.0
+Bounds
+ X free
+ Y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_3 = +1
+ c2: +1 x_4 = +1
+ c3: -1 x_0 -1 x_2 <= +0
+ c4: -1 x_1 -1 x_2 <= +0
+ c5: -1 x_3 -1 x_5 <= +0
+ c6: -1 x_4 -1 x_5 <= +0
+ c7: +1 x_2 +1 x_5 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ min_1_0: +1 X_0 -1 min_1 >= +0
+ min_1_1: +1 X_1 -1 min_1 >= +0
+ min_2_0: +1 Y_0 -1 min_2 >= +0
+ min_2_1: +1 Y_1 -1 min_2 >= +0
+ 28: +1 min_1 +1 min_2 >= +1
+ 33_0: +1 Y_0 = +1
+ 33_1: +1 Y_1 = +1
+Bounds
+ X_0 free
+ X_1 free
+ min_1 free
+ Y_0 free
+ Y_1 free
+ min_2 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_20.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_20.txt
@@ -1,0 +1,44 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 40: 1.0 <= min(X + Y, None, False)
+ 45: Y == 1.0
+Bounds
+ X free
+ Y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: +1 x_2 = +1
+ c2: +1 x_3 = +1
+ c3: -1 x_0 -1 x_2 -1 x_4 <= +0
+ c4: -1 x_1 -1 x_3 -1 x_4 <= +0
+ c5: +1 x_4 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ min_1_0: +1 X_0 +1 Y_0 -1 min_1 >= +0
+ min_1_1: +1 X_1 +1 Y_1 -1 min_1 >= +0
+ 40: +1 min_1 >= +1
+ 45_0: +1 Y_0 = +1
+ 45_1: +1 Y_1 = +1
+Bounds
+ X_0 free
+ X_1 free
+ Y_0 free
+ Y_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_21.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_21.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 52: 1.0 <= min(X + [ 1. -2.], None, False)
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 -1 x_2 <= +1
+ c2: -1 x_1 -1 x_2 <= -2
+ c3: +1 x_2 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ min_1_0: +1 X_0 -1 min_1 >= -1
+ min_1_1: +1 X_1 -1 min_1 >= +2
+ 52: +1 min_1 >= +1
+Bounds
+ X_0 free
+ X_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_22.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_22.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 60: 1.0 <= min(X, None, False) + min([ 1. -2.], None, False)
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1
+Subject to
+ c1: -1 x_0 -1 x_2 <= +0
+ c2: -1 x_1 -1 x_2 <= +0
+ c3: +1 x_2 <= -3
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ min_1_0: +1 X_0 -1 min_1 >= +0
+ min_1_1: +1 X_1 -1 min_1 >= +0
+ 60: +1 min_1 >= +3
+Bounds
+ X_0 free
+ X_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_23.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_23.txt
@@ -1,0 +1,36 @@
+CVXPY
+Minimize
+  max(X, None, False)
+Subject To
+ 5: 1.0 <= X
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 +1 x_1 <= +0
+ c2: -1 x_0 +1 x_2 <= +0
+ c3: -1 x_1 <= -1
+ c4: -1 x_2 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 max_1
+Subject to
+ max_1_0: +1 X_0 -1 max_1 <= +0
+ max_1_1: +1 X_1 -1 max_1 <= +0
+ 5_0: +1 X_0 >= +1
+ 5_1: +1 X_1 >= +1
+Bounds
+ X_0 free
+ X_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_24.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_24.txt
@@ -1,0 +1,34 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 11: max(X, None, False) <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 -1 x_2 <= +0
+ c2: +1 x_1 -1 x_2 <= +0
+ c3: +1 x_2 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ max_1_0: +1 X_0 -1 max_1 <= +0
+ max_1_1: +1 X_1 -1 max_1 <= +0
+ 11: +1 max_1 <= +1
+Bounds
+ X_0 free
+ X_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_25.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_25.txt
@@ -1,0 +1,34 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 18: max(X, None, False) + 1.0 <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 -1 x_2 <= +0
+ c2: +1 x_1 -1 x_2 <= +0
+ c3: +1 x_2 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ max_1_0: +1 X_0 -1 max_1 <= +0
+ max_1_1: +1 X_1 -1 max_1 <= +0
+ 18: +1 max_1 <= +0
+Bounds
+ X_0 free
+ X_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_26.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_26.txt
@@ -1,0 +1,50 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 26: max(X, None, False) + max(Y, None, False) <= 1.0
+ 31: Y == 1.0
+Bounds
+ X free
+ Y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_3 = +1
+ c2: +1 x_4 = +1
+ c3: +1 x_0 -1 x_2 <= +0
+ c4: +1 x_1 -1 x_2 <= +0
+ c5: +1 x_3 -1 x_5 <= +0
+ c6: +1 x_4 -1 x_5 <= +0
+ c7: +1 x_2 +1 x_5 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ max_1_0: +1 X_0 -1 max_1 <= +0
+ max_1_1: +1 X_1 -1 max_1 <= +0
+ max_2_0: +1 Y_0 -1 max_2 <= +0
+ max_2_1: +1 Y_1 -1 max_2 <= +0
+ 26: +1 max_1 +1 max_2 <= +1
+ 31_0: +1 Y_0 = +1
+ 31_1: +1 Y_1 = +1
+Bounds
+ X_0 free
+ X_1 free
+ max_1 free
+ Y_0 free
+ Y_1 free
+ max_2 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_27.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_27.txt
@@ -1,0 +1,44 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 38: max(X + Y, None, False) <= 1.0
+ 43: Y == 1.0
+Bounds
+ X free
+ Y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_2 = +1
+ c2: +1 x_3 = +1
+ c3: +1 x_0 +1 x_2 -1 x_4 <= +0
+ c4: +1 x_1 +1 x_3 -1 x_4 <= +0
+ c5: +1 x_4 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ max_1_0: +1 X_0 +1 Y_0 -1 max_1 <= +0
+ max_1_1: +1 X_1 +1 Y_1 -1 max_1 <= +0
+ 38: +1 max_1 <= +1
+ 43_0: +1 Y_0 = +1
+ 43_1: +1 Y_1 = +1
+Bounds
+ X_0 free
+ X_1 free
+ Y_0 free
+ Y_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_28.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_28.txt
@@ -1,0 +1,34 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 50: max(X + [ 1. -2.], None, False) <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 -1 x_2 <= -1
+ c2: +1 x_1 -1 x_2 <= +2
+ c3: +1 x_2 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ max_1_0: +1 X_0 -1 max_1 <= -1
+ max_1_1: +1 X_1 -1 max_1 <= +2
+ 50: +1 max_1 <= +1
+Bounds
+ X_0 free
+ X_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_29.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_29.txt
@@ -1,0 +1,34 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 58: max(X, None, False) + max([ 1. -2.], None, False) <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1
+Subject to
+ c1: +1 x_0 -1 x_2 <= +0
+ c2: +1 x_1 -1 x_2 <= +0
+ c3: +1 x_2 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0 +1 X_1
+Subject to
+ max_1_0: +1 X_0 -1 max_1 <= +0
+ max_1_1: +1 X_1 -1 max_1 <= +0
+ 58: +1 max_1 <= +0
+Bounds
+ X_0 free
+ X_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_30.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_30.txt
@@ -1,0 +1,48 @@
+CVXPY
+Maximize
+  min(X, None, False)
+Subject To
+ 7: X <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 -1 x_1 <= +0
+ c2: -1 x_0 -1 x_2 <= +0
+ c3: -1 x_0 -1 x_3 <= +0
+ c4: -1 x_0 -1 x_4 <= +0
+ c5: +1 x_1 <= +1
+ c6: +1 x_2 <= +1
+ c7: +1 x_3 <= +1
+ c8: +1 x_4 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 min_1
+Subject to
+ min_1_0_0: +1 X_0_0 -1 min_1 >= +0
+ min_1_0_1: +1 X_0_1 -1 min_1 >= +0
+ min_1_1_0: +1 X_1_0 -1 min_1 >= +0
+ min_1_1_1: +1 X_1_1 -1 min_1 >= +0
+ 7_0_0: +1 X_0_0 <= +1
+ 7_0_1: +1 X_0_1 <= +1
+ 7_1_0: +1 X_1_0 <= +1
+ 7_1_1: +1 X_1_1 <= +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_31.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_31.txt
@@ -1,0 +1,42 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 13: 1.0 <= min(X, None, False)
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ c1: -1 x_0 -1 x_4 <= +0
+ c2: -1 x_1 -1 x_4 <= +0
+ c3: -1 x_2 -1 x_4 <= +0
+ c4: -1 x_3 -1 x_4 <= +0
+ c5: +1 x_4 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ min_1_0_0: +1 X_0_0 -1 min_1 >= +0
+ min_1_0_1: +1 X_0_1 -1 min_1 >= +0
+ min_1_1_0: +1 X_1_0 -1 min_1 >= +0
+ min_1_1_1: +1 X_1_1 -1 min_1 >= +0
+ 13: +1 min_1 >= +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_32.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_32.txt
@@ -1,0 +1,42 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 20: 1.0 <= min(X, None, False) + 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ c1: -1 x_0 -1 x_4 <= +0
+ c2: -1 x_1 -1 x_4 <= +0
+ c3: -1 x_2 -1 x_4 <= +0
+ c4: -1 x_3 -1 x_4 <= +0
+ c5: +1 x_4 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ min_1_0_0: +1 X_0_0 -1 min_1 >= +0
+ min_1_0_1: +1 X_0_1 -1 min_1 >= +0
+ min_1_1_0: +1 X_1_0 -1 min_1 >= +0
+ min_1_1_1: +1 X_1_1 -1 min_1 >= +0
+ 20: +1 min_1 >= +0
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_33.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_33.txt
@@ -1,0 +1,70 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 28: 1.0 <= min(X, None, False) + min(Y, None, False)
+ 33: Y == 1.0
+Bounds
+ X free
+ Y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ c1: +1 x_5 = +1
+ c2: +1 x_6 = +1
+ c3: +1 x_7 = +1
+ c4: +1 x_8 = +1
+ c5: -1 x_0 -1 x_4 <= +0
+ c6: -1 x_1 -1 x_4 <= +0
+ c7: -1 x_2 -1 x_4 <= +0
+ c8: -1 x_3 -1 x_4 <= +0
+ c9: -1 x_5 -1 x_9 <= +0
+ c10: -1 x_6 -1 x_9 <= +0
+ c11: -1 x_7 -1 x_9 <= +0
+ c12: -1 x_8 -1 x_9 <= +0
+ c13: +1 x_4 +1 x_9 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+ x_6 free
+ x_7 free
+ x_8 free
+ x_9 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ min_1_0_0: +1 X_0_0 -1 min_1 >= +0
+ min_1_0_1: +1 X_0_1 -1 min_1 >= +0
+ min_1_1_0: +1 X_1_0 -1 min_1 >= +0
+ min_1_1_1: +1 X_1_1 -1 min_1 >= +0
+ min_2_0_0: +1 Y_0_0 -1 min_2 >= +0
+ min_2_0_1: +1 Y_0_1 -1 min_2 >= +0
+ min_2_1_0: +1 Y_1_0 -1 min_2 >= +0
+ min_2_1_1: +1 Y_1_1 -1 min_2 >= +0
+ 28: +1 min_1 +1 min_2 >= +1
+ 33_0_0: +1 Y_0_0 = +1
+ 33_0_1: +1 Y_0_1 = +1
+ 33_1_0: +1 Y_1_0 = +1
+ 33_1_1: +1 Y_1_1 = +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ min_1 free
+ Y_0_0 free
+ Y_0_1 free
+ Y_1_0 free
+ Y_1_1 free
+ min_2 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_34.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_34.txt
@@ -1,0 +1,60 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 40: 1.0 <= min(X + Y, None, False)
+ 45: Y == 1.0
+Bounds
+ X free
+ Y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ c1: +1 x_4 = +1
+ c2: +1 x_5 = +1
+ c3: +1 x_6 = +1
+ c4: +1 x_7 = +1
+ c5: -1 x_0 -1 x_4 -1 x_8 <= +0
+ c6: -1 x_1 -1 x_5 -1 x_8 <= +0
+ c7: -1 x_2 -1 x_6 -1 x_8 <= +0
+ c8: -1 x_3 -1 x_7 -1 x_8 <= +0
+ c9: +1 x_8 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+ x_6 free
+ x_7 free
+ x_8 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ min_1_0_0: +1 X_0_0 +1 Y_0_0 -1 min_1 >= +0
+ min_1_0_1: +1 X_0_1 +1 Y_0_1 -1 min_1 >= +0
+ min_1_1_0: +1 X_1_0 +1 Y_1_0 -1 min_1 >= +0
+ min_1_1_1: +1 X_1_1 +1 Y_1_1 -1 min_1 >= +0
+ 40: +1 min_1 >= +1
+ 45_0_0: +1 Y_0_0 = +1
+ 45_0_1: +1 Y_0_1 = +1
+ 45_1_0: +1 Y_1_0 = +1
+ 45_1_1: +1 Y_1_1 = +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ Y_0_0 free
+ Y_0_1 free
+ Y_1_0 free
+ Y_1_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_35.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_35.txt
@@ -1,0 +1,43 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 52: 1.0 <= min(X + [[1.00 -2.00]
+ [3.00 4.00]], None, False)
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ c1: -1 x_0 -1 x_4 <= +1
+ c2: -1 x_1 -1 x_4 <= +3
+ c3: -1 x_2 -1 x_4 <= -2
+ c4: -1 x_3 -1 x_4 <= +4
+ c5: +1 x_4 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ min_1_0_0: +1 X_0_0 -1 min_1 >= -1
+ min_1_0_1: +1 X_0_1 -1 min_1 >= +2
+ min_1_1_0: +1 X_1_0 -1 min_1 >= -3
+ min_1_1_1: +1 X_1_1 -1 min_1 >= -4
+ 52: +1 min_1 >= +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_36.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_36.txt
@@ -1,0 +1,43 @@
+CVXPY
+Minimize
+  Sum(X, None, False)
+Subject To
+ 60: 1.0 <= min(X, None, False) + min([[1.00 -2.00]
+ [3.00 4.00]], None, False)
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
+Subject to
+ c1: -1 x_0 -1 x_4 <= +0
+ c2: -1 x_1 -1 x_4 <= +0
+ c3: -1 x_2 -1 x_4 <= +0
+ c4: -1 x_3 -1 x_4 <= +0
+ c5: +1 x_4 <= -3
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ min_1_0_0: +1 X_0_0 -1 min_1 >= +0
+ min_1_0_1: +1 X_0_1 -1 min_1 >= +0
+ min_1_1_0: +1 X_1_0 -1 min_1 >= +0
+ min_1_1_1: +1 X_1_1 -1 min_1 >= +0
+ 60: +1 min_1 >= +3
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ min_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_37.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_37.txt
@@ -1,0 +1,48 @@
+CVXPY
+Minimize
+  max(X, None, False)
+Subject To
+ 5: 1.0 <= X
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 +1 x_1 <= +0
+ c2: -1 x_0 +1 x_2 <= +0
+ c3: -1 x_0 +1 x_3 <= +0
+ c4: -1 x_0 +1 x_4 <= +0
+ c5: -1 x_1 <= -1
+ c6: -1 x_2 <= -1
+ c7: -1 x_3 <= -1
+ c8: -1 x_4 <= -1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 max_1
+Subject to
+ max_1_0_0: +1 X_0_0 -1 max_1 <= +0
+ max_1_0_1: +1 X_0_1 -1 max_1 <= +0
+ max_1_1_0: +1 X_1_0 -1 max_1 <= +0
+ max_1_1_1: +1 X_1_1 -1 max_1 <= +0
+ 5_0_0: +1 X_0_0 >= +1
+ 5_0_1: +1 X_0_1 >= +1
+ 5_1_0: +1 X_1_0 >= +1
+ 5_1_1: +1 X_1_1 >= +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_38.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_38.txt
@@ -1,0 +1,42 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 11: max(X, None, False) <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 -1 x_4 <= +0
+ c2: +1 x_1 -1 x_4 <= +0
+ c3: +1 x_2 -1 x_4 <= +0
+ c4: +1 x_3 -1 x_4 <= +0
+ c5: +1 x_4 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ max_1_0_0: +1 X_0_0 -1 max_1 <= +0
+ max_1_0_1: +1 X_0_1 -1 max_1 <= +0
+ max_1_1_0: +1 X_1_0 -1 max_1 <= +0
+ max_1_1_1: +1 X_1_1 -1 max_1 <= +0
+ 11: +1 max_1 <= +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_39.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_39.txt
@@ -1,0 +1,42 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 18: max(X, None, False) + 1.0 <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 -1 x_4 <= +0
+ c2: +1 x_1 -1 x_4 <= +0
+ c3: +1 x_2 -1 x_4 <= +0
+ c4: +1 x_3 -1 x_4 <= +0
+ c5: +1 x_4 <= +0
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ max_1_0_0: +1 X_0_0 -1 max_1 <= +0
+ max_1_0_1: +1 X_0_1 -1 max_1 <= +0
+ max_1_1_0: +1 X_1_0 -1 max_1 <= +0
+ max_1_1_1: +1 X_1_1 -1 max_1 <= +0
+ 18: +1 max_1 <= +0
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_40.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_40.txt
@@ -1,0 +1,70 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 26: max(X, None, False) + max(Y, None, False) <= 1.0
+ 31: Y == 1.0
+Bounds
+ X free
+ Y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_5 = +1
+ c2: +1 x_6 = +1
+ c3: +1 x_7 = +1
+ c4: +1 x_8 = +1
+ c5: +1 x_0 -1 x_4 <= +0
+ c6: +1 x_1 -1 x_4 <= +0
+ c7: +1 x_2 -1 x_4 <= +0
+ c8: +1 x_3 -1 x_4 <= +0
+ c9: +1 x_5 -1 x_9 <= +0
+ c10: +1 x_6 -1 x_9 <= +0
+ c11: +1 x_7 -1 x_9 <= +0
+ c12: +1 x_8 -1 x_9 <= +0
+ c13: +1 x_4 +1 x_9 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+ x_6 free
+ x_7 free
+ x_8 free
+ x_9 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ max_1_0_0: +1 X_0_0 -1 max_1 <= +0
+ max_1_0_1: +1 X_0_1 -1 max_1 <= +0
+ max_1_1_0: +1 X_1_0 -1 max_1 <= +0
+ max_1_1_1: +1 X_1_1 -1 max_1 <= +0
+ max_2_0_0: +1 Y_0_0 -1 max_2 <= +0
+ max_2_0_1: +1 Y_0_1 -1 max_2 <= +0
+ max_2_1_0: +1 Y_1_0 -1 max_2 <= +0
+ max_2_1_1: +1 Y_1_1 -1 max_2 <= +0
+ 26: +1 max_1 +1 max_2 <= +1
+ 31_0_0: +1 Y_0_0 = +1
+ 31_0_1: +1 Y_0_1 = +1
+ 31_1_0: +1 Y_1_0 = +1
+ 31_1_1: +1 Y_1_1 = +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ max_1 free
+ Y_0_0 free
+ Y_0_1 free
+ Y_1_0 free
+ Y_1_1 free
+ max_2 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_41.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_41.txt
@@ -1,0 +1,60 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 38: max(X + Y, None, False) <= 1.0
+ 43: Y == 1.0
+Bounds
+ X free
+ Y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_4 = +1
+ c2: +1 x_5 = +1
+ c3: +1 x_6 = +1
+ c4: +1 x_7 = +1
+ c5: +1 x_0 +1 x_4 -1 x_8 <= +0
+ c6: +1 x_1 +1 x_5 -1 x_8 <= +0
+ c7: +1 x_2 +1 x_6 -1 x_8 <= +0
+ c8: +1 x_3 +1 x_7 -1 x_8 <= +0
+ c9: +1 x_8 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+ x_5 free
+ x_6 free
+ x_7 free
+ x_8 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ max_1_0_0: +1 X_0_0 +1 Y_0_0 -1 max_1 <= +0
+ max_1_0_1: +1 X_0_1 +1 Y_0_1 -1 max_1 <= +0
+ max_1_1_0: +1 X_1_0 +1 Y_1_0 -1 max_1 <= +0
+ max_1_1_1: +1 X_1_1 +1 Y_1_1 -1 max_1 <= +0
+ 38: +1 max_1 <= +1
+ 43_0_0: +1 Y_0_0 = +1
+ 43_0_1: +1 Y_0_1 = +1
+ 43_1_0: +1 Y_1_0 = +1
+ 43_1_1: +1 Y_1_1 = +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ Y_0_0 free
+ Y_0_1 free
+ Y_1_0 free
+ Y_1_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_42.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_42.txt
@@ -1,0 +1,43 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 50: max(X + [[1.00 -2.00]
+ [3.00 4.00]], None, False) <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 -1 x_4 <= -1
+ c2: +1 x_1 -1 x_4 <= -3
+ c3: +1 x_2 -1 x_4 <= +2
+ c4: +1 x_3 -1 x_4 <= -4
+ c5: +1 x_4 <= +1
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ max_1_0_0: +1 X_0_0 -1 max_1 <= -1
+ max_1_0_1: +1 X_0_1 -1 max_1 <= +2
+ max_1_1_0: +1 X_1_0 -1 max_1 <= -3
+ max_1_1_1: +1 X_1_1 -1 max_1 <= -4
+ 50: +1 max_1 <= +1
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ max_1 free
+End

--- a/tests/snapshots/scip/lp__genexpr_min_max_43.txt
+++ b/tests/snapshots/scip/lp__genexpr_min_max_43.txt
@@ -1,0 +1,43 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 58: max(X, None, False) + max([[1.00 -2.00]
+ [3.00 4.00]], None, False) <= 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
+Subject to
+ c1: +1 x_0 -1 x_4 <= +0
+ c2: +1 x_1 -1 x_4 <= +0
+ c3: +1 x_2 -1 x_4 <= +0
+ c4: +1 x_3 -1 x_4 <= +0
+ c5: +1 x_4 <= -3
+Bounds
+ x_0 free
+ x_1 free
+ x_2 free
+ x_3 free
+ x_4 free
+End
+----------------------------------------
+SCIP
+Maximize
+ Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
+Subject to
+ max_1_0_0: +1 X_0_0 -1 max_1 <= +0
+ max_1_0_1: +1 X_0_1 -1 max_1 <= +0
+ max_1_1_0: +1 X_1_0 -1 max_1 <= +0
+ max_1_1_1: +1 X_1_1 -1 max_1 <= +0
+ 58: +1 max_1 <= -3
+Bounds
+ X_0_0 free
+ X_0_1 free
+ X_1_0 free
+ X_1_1 free
+ max_1 free
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -314,7 +314,6 @@ def genexpr_abs() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(cp.abs(x) + cp.abs(A))))
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @group_cases("genexpr_min_max")
 def genexpr_min_max() -> Generator[cp.Problem]:
     x = cp.Variable(name="x")


### PR DESCRIPTION
Have to do it by hand, but it's not complicated as long as we assume the problem is nicely convex (which it should be coming from CVXPY).