### PR TITLE
Use common exception hierarchy

### DIFF
--- a/src/cvxpy_translation/__init__.py
+++ b/src/cvxpy_translation/__init__.py
@@ -1,4 +1,10 @@
-from cvxpy_translation._version import __version__
-from cvxpy_translation._version import __version_tuple__
-
-__all__ = ("__version__", "__version_tuple__")
+from cvxpy_translation._version import __version__ as __version__
+from cvxpy_translation._version import __version_tuple__ as __version_tuple__
+from cvxpy_translation.exceptions import InvalidParameterError as InvalidParameterError
+from cvxpy_translation.exceptions import (
+    UnsupportedConstraintError as UnsupportedConstraintError,
+)
+from cvxpy_translation.exceptions import UnsupportedError as UnsupportedError
+from cvxpy_translation.exceptions import (
+    UnsupportedExpressionError as UnsupportedExpressionError,
+)

--- a/src/cvxpy_translation/exceptions.py
+++ b/src/cvxpy_translation/exceptions.py
@@ -1,0 +1,21 @@
+from cvxpy.utilities.canonical import Canonical
+
+
+class UnsupportedError(ValueError):
+    msg_template = "Unsupported CVXPY node: {node}"
+
+    def __init__(self, node: Canonical) -> None:
+        super().__init__(self.msg_template.format(node=node, klass=type(node)))
+        self.node = node
+
+
+class UnsupportedConstraintError(UnsupportedError):
+    msg_template = "Unsupported CVXPY constraint: {node}"
+
+
+class UnsupportedExpressionError(UnsupportedError):
+    msg_template = "Unsupported CVXPY expression: {node} ({klass})"
+
+
+class InvalidParameterError(UnsupportedExpressionError):
+    msg_template = "Unsupported parameter: value for {node} is not set"

--- a/src/cvxpy_translation/gurobi/translation.py
+++ b/src/cvxpy_translation/gurobi/translation.py
@@ -17,6 +17,11 @@ import gurobipy as gp
 import numpy as np
 import numpy.typing as npt
 
+from cvxpy_translation.exceptions import InvalidParameterError
+from cvxpy_translation.exceptions import UnsupportedConstraintError
+from cvxpy_translation.exceptions import UnsupportedError
+from cvxpy_translation.exceptions import UnsupportedExpressionError
+
 if TYPE_CHECKING:
     from cvxpy.atoms.affine.add_expr import AddExpression
     from cvxpy.atoms.affine.binary_operators import DivExpression
@@ -49,22 +54,6 @@ Param: TypeAlias = Union[str, float]
 ParamDict: TypeAlias = Dict[str, Param]
 
 
-class UnsupportedError(ValueError):
-    msg_template = "Unsupported CVXPY node: {node}"
-
-    def __init__(self, node: Canonical) -> None:
-        super().__init__(self.msg_template.format(node=node, klass=type(node)))
-        self.node = node
-
-
-class UnsupportedConstraintError(UnsupportedError):
-    msg_template = "Unsupported CVXPY constraint: {node}"
-
-
-class UnsupportedExpressionError(UnsupportedError):
-    msg_template = "Unsupported CVXPY expression: {node} ({klass})"
-
-
 class InvalidPowerError(UnsupportedExpressionError):
     msg_template = "Unsupported power: {node}, only quadratic expressions are supported"
 
@@ -79,10 +68,6 @@ class InvalidNonlinearAtomError(UnsupportedExpressionError):
     msg_template = (
         "Unsupported nonlinear atom: {node}, upgrade your version of gurobipy"
     )
-
-
-class InvalidParameterError(UnsupportedExpressionError):
-    msg_template = "Unsupported parameter: value for {node} is not set"
 
 
 def _shape(expr: Any) -> tuple[int, ...]:

--- a/src/cvxpy_translation/scip/__init__.py
+++ b/src/cvxpy_translation/scip/__init__.py
@@ -3,7 +3,6 @@ from cvxpy_translation.scip.interface import backfill_problem
 from cvxpy_translation.scip.interface import build_model
 from cvxpy_translation.scip.interface import register_solver
 from cvxpy_translation.scip.interface import solve
-from cvxpy_translation.scip.translation import InvalidNonlinearAtomError
 from cvxpy_translation.scip.translation import InvalidNormError
 from cvxpy_translation.scip.translation import InvalidParameterError
 from cvxpy_translation.scip.translation import InvalidPowerError
@@ -13,7 +12,6 @@ from cvxpy_translation.scip.translation import UnsupportedExpressionError
 
 __all__ = (
     "SCIP_TRANSLATION",
-    "InvalidNonlinearAtomError",
     "InvalidNormError",
     "InvalidParameterError",
     "InvalidPowerError",

--- a/tests/snapshots/scip/lp__scalar_stack_00.txt
+++ b/tests/snapshots/scip/lp__scalar_stack_00.txt
@@ -1,0 +1,23 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(x, (1,), F), reshape(1.0, (1,), F)), None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= +0
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x +1
+Subject to
+Bounds
+End

--- a/tests/snapshots/scip/lp__scalar_stack_01.txt
+++ b/tests/snapshots/scip/lp__scalar_stack_01.txt
@@ -1,0 +1,23 @@
+CVXPY
+Minimize
+  Sum(Vstack(x, 1.0), None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= +0
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x +1
+Subject to
+Bounds
+End

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -1,49 +1,72 @@
+import inspect
+from typing import Any
+
 import cvxpy as cp
 import gurobipy as gp
+import pyscipopt as scip
 import pytest
 
-import cvxpy_translation.gurobi
+import cvxpy_translation
 import test_problems
-from cvxpy_translation.gurobi.translation import Translater
+from cvxpy_translation.gurobi.translation import Translater as GrbTranslater
+from cvxpy_translation.scip.translation import Translater as ScipTranslater
+
+
+@pytest.fixture(params=[GrbTranslater(gp.Model()), ScipTranslater(scip.Model())])
+def translater(request: pytest.FixtureRequest) -> Any:
+    return request.param
 
 
 @pytest.mark.xfail(reason="TODO: implement all atoms")
-def test_no_missing_atoms() -> None:
-    missing = [
+def test_no_missing_atoms(translater: Any) -> None:
+    missing = {
         atom
         for atom in cp.EXP_ATOMS + cp.PSD_ATOMS + cp.SOC_ATOMS + cp.NONPOS_ATOMS
-        if getattr(Translater, f"visit_{atom.__name__}", None) is None  # type: ignore[attr-defined]
-    ]
-    assert missing == []
+        if inspect.isclass(atom)
+        and getattr(translater, f"visit_{atom.__name__}", None) is None  # type: ignore[attr-defined]
+    }
+    assert missing == set()
 
 
-@pytest.mark.parametrize("case", test_problems.all_invalid_problems())
-def test_failing_atoms(case: test_problems.ProblemTestCase) -> None:
-    if case.skip_reason:
-        pytest.skip(case.skip_reason)
-    translater = Translater(gp.Model())
-    with pytest.raises(cvxpy_translation.gurobi.UnsupportedExpressionError):
-        translater.visit(case.problem.objective.expr)
+@pytest.fixture(params=test_problems.all_invalid_problems())
+def invalid_case(request: pytest.FixtureRequest) -> test_problems.ProblemTestCase:
+    return request.param
 
 
-def test_parameter() -> None:
-    translater = Translater(gp.Model())
+@pytest.fixture
+def invalid_case_translater(invalid_case: test_problems.ProblemTestCase) -> Any:
+    return (
+        GrbTranslater(gp.Model())
+        if invalid_case.context.solver == cp.GUROBI
+        else ScipTranslater(scip.Model())
+    )
+
+
+def test_failing_atoms(
+    invalid_case: test_problems.ProblemTestCase, invalid_case_translater: Any
+) -> None:
+    if invalid_case.skip_reason:
+        pytest.skip(invalid_case.skip_reason)
+    with pytest.raises(cvxpy_translation.UnsupportedExpressionError):
+        invalid_case_translater.visit(invalid_case.problem.objective.expr)
+
+
+def test_parameter(translater: Any) -> None:
     p = cp.Parameter()
     # Non-happy path raises
-    with pytest.raises(cvxpy_translation.gurobi.InvalidParameterError):
+    with pytest.raises(cvxpy_translation.InvalidParameterError):
         translater.visit(p)
     # Happy path succeeds
     p.value = 1
     translater.visit(p)
 
 
-def test_parameter_reshape() -> None:
+def test_parameter_reshape(translater: Any) -> None:
     """From https://github.com/jonathanberthias/cvxpy-translation/issues/76.
 
     Parameter.value is not necessarily a numpy/scipy array,
     so reshaping is not always straightforward.
     """
-    translater = Translater(gp.Model())
     p = cp.Parameter()
     p.value = 1
     translater.visit(cp.reshape(p, (1,), order="C"))

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -817,7 +817,6 @@ def attributes() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Maximize(x + n + b), [n <= 1])
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
 @group_cases("invalid", invalid_reason="unsupported expressions")
 def invalid_expressions() -> Generator[cp.Problem]:
     x = cp.Variable(name="x")
@@ -829,10 +828,21 @@ def invalid_expressions() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.norm(v, 0.5)))
 
 
-@skipif(lambda case: case.context.solver == cp.SCIP, "TODO")
+@skipif(
+    lambda case: case.context.solver == cp.GUROBI,
+    "hstack variant not supported by gurobipy",
+)
+@group_cases("scalar_stack")
+def scalar_stack() -> Generator[cp.Problem]:
+    x = cp.Variable(name="x", nonneg=True)
+    yield cp.Problem(cp.Minimize(cp.sum(cp.hstack([x, 1]))))
+    yield cp.Problem(cp.Minimize(cp.sum(cp.vstack([x, 1]))))
+
+
+@skipif(lambda case: case.context.solver == cp.SCIP, "works with SCIP")
 @skipif(
     lambda case: case.context.solver == cp.GUROBI and GUROBI_MAJOR >= 11,
-    "works in Gurobi 11+",
+    "stack functions exist in Gurobi 11+",
 )
 @group_cases("invalid_stack", invalid_reason="unsupported stack expressions")
 def invalid_stack_expressions() -> Generator[cp.Problem]:


### PR DESCRIPTION
Move the base exceptions to the library root, which makes it possible to catch exceptions no matter which solver/translater is used.
This enables us to unblock the tests for invalid cases for both SCIP and Gurobi.

There is something weird going on with gurobipy's `hstack`, not sure why. There's no issue with `vstack`. But for now we just skip both on Gurobi.