### PR TITLE
Remove unused methods from SCIP implementation

### DIFF
--- a/src/cvxpy_translation/__init__.py
+++ b/src/cvxpy_translation/__init__.py
@@ -12,7 +12,6 @@ from cvxpy_translation.exceptions import (
 )
 from cvxpy_translation.interface import backfill_problem as backfill_problem
 from cvxpy_translation.interface import build_model as build_model
-from cvxpy_translation.interface import fill_model as fill_model
 from cvxpy_translation.interface import (
     register_translation_solver as register_translation_solver,
 )

--- a/src/cvxpy_translation/gurobi/interface.py
+++ b/src/cvxpy_translation/gurobi/interface.py
@@ -230,8 +230,8 @@ def get_constraint_by_name(model: gp.Model, name: str) -> gp.Constr | gp.QConstr
     else:
         if constr is not None:
             return constr
-    msg = f"Constraint {name} not found."
-    raise LookupError(msg)
+    msg = f"Constraint {name} not found."  # pragma: no cover
+    raise LookupError(msg)  # pragma: no cover
 
 
 def _matrix_to_gurobi_names(

--- a/src/cvxpy_translation/interface.py
+++ b/src/cvxpy_translation/interface.py
@@ -77,27 +77,6 @@ def build_model(
     raise NotImplementedError(msg)
 
 
-def fill_model(problem: cp.Problem, model: gp.Model | scip.Model) -> None:
-    """Add the objective and constraints from a CVXPY problem to a native model.
-
-    Args:
-        problem: The CVXPY problem to convert.
-        model: The native model to which constraints and objectives are added.
-
-    """
-    if gurobi_available and isinstance(model, gp.Model):
-        from cvxpy_translation.gurobi.interface import fill_model as fill_gurobi_model
-
-        fill_gurobi_model(problem, model)
-    elif scip_available and isinstance(model, scip.Model):
-        from cvxpy_translation.scip.interface import fill_model as fill_scip_model
-
-        fill_scip_model(problem, model)
-    else:
-        msg = f"Unsupported model type: {type(model)}, expected gp.Model or scip.Model"
-        raise NotImplementedError(msg)
-
-
 def backfill_problem(
     problem: cp.Problem,
     model: gp.Model | scip.Model,

--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -204,8 +204,8 @@ def get_constraint_by_name(model: scip.Model, name: str) -> scip.Constraint:
     for constr in constrs:
         if constr.name == name:
             return constr
-    msg = f"Constraint {name} not found."
-    raise LookupError(msg)
+    msg = f"Constraint {name} not found."  # pragma: no cover
+    raise LookupError(msg)  # pragma: no cover
 
 
 def _matrix_to_scip_names(

--- a/src/cvxpy_translation/scip/translation.py
+++ b/src/cvxpy_translation/scip/translation.py
@@ -5,9 +5,7 @@ from functools import reduce
 from math import prod
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import Dict
-from typing import Iterator
 from typing import Literal
 from typing import Union
 from typing import overload
@@ -69,55 +67,6 @@ def _is_scalar_shape(shape: tuple[int, ...]) -> bool:
 
 def _is_scalar(expr: Any) -> bool:
     return _is_scalar_shape(_shape(expr))
-
-
-def _squeeze_shape(shape: tuple[int, ...]) -> tuple[int, ...]:
-    return tuple(d for d in shape if d != 1)
-
-
-def iterzip_subexpressions(
-    *exprs: Any, shape: tuple[int, ...]
-) -> Iterator[tuple[Any, ...]]:
-    for idx in np.ndindex(shape):
-        idx_exprs = []
-        for expr in exprs:
-            if _shape(expr) == ():
-                idx_exprs.append(expr)
-            elif _is_scalar(expr):
-                item = expr[(0,) * len(idx)]
-                idx_exprs.append(item)
-            else:
-                idx_exprs.append(expr[idx])
-        yield tuple(idx_exprs)
-
-
-def iter_subexpressions(expr: Any, shape: tuple[int, ...]) -> Iterator[Any]:
-    for exprs in iterzip_subexpressions(expr, shape=shape):
-        yield exprs[0]
-
-
-def to_subexpressions_array(expr: Any, shape: tuple[int, ...]) -> npt.NDArray:
-    return np.fromiter(
-        iter_subexpressions(expr, shape=shape), dtype=np.object_
-    ).reshape(shape)
-
-
-def to_zipped_subexpressions_array(
-    *exprs: Any, shape: tuple[int, ...]
-) -> npt.NDArray[np.object_]:
-    return np.fromiter(
-        iterzip_subexpressions(*exprs, shape=shape), dtype=np.object_
-    ).reshape(shape)
-
-
-def promote_array_to_scip_matrixapi(array: npt.NDArray[np.object_]) -> Any:
-    """Promote an array of Gurobi objects to the equivalent Gurobi matrixapi object."""
-    kind = type(array.flat[0])
-    if issubclass(kind, scip.Variable):
-        return scip.MatrixVariable(array)
-    # TODO: support other types
-    msg = f"Cannot promote array of {kind}"
-    raise NotImplementedError(msg)  # pragma: no cover
 
 
 def translate_variable(var: cp.Variable, model: scip.Model) -> AnyVar:
@@ -230,49 +179,17 @@ class Translater:
         # but let's assume it always has an `item` method
         return expr.item()
 
-    def translate_into_variable(
-        self,
-        node: cp.Expression,
-        *,
-        scalar: bool = False,
-        vtype: str = "CONTINUOUS",
-        lb: float | None = None,
-        ub: float | None = None,
-    ) -> AnyVar | npt.NDArray[np.float64] | float:
-        """Translate a CVXPY expression, and return a gurobipy variable constrained to its value.
-
-        This is useful for gurobipy functions that only handle variables as their arguments.
-        If translating the expression results in a variable, it is returned directly.
-        Constants are also returned directly.
-        If scalar is True, the result is guaranteed to be a scalar, otherwise its shape will be
-        the shape of whatever gets generated while translating the node.
-        """
-        expr = self.visit(node)
-        if isinstance(expr, scip.Variable):
-            return expr
-        if isinstance(expr, (scip.MatrixVariable, np.ndarray)):
-            if scalar:
-                # Extract the underlying variable - will raise an error if the shape is not scalar
-                return expr.item()  # type: ignore[return-value]
-            return expr
-        return self.make_auxilliary_variable_for(
-            expr, node.__class__.__name__, vtype=vtype, lb=lb, ub=ub
-        )
-
     def make_auxilliary_variable_for(
         self,
         expr: Any,
         atom_name: str,
         *,
-        desired_shape: tuple[int, ...] | None = None,
+        desired_shape: tuple[int, ...],
         vtype: str = "CONTINUOUS",
         lb: float | None = None,
         ub: float | None = None,
-    ) -> AnyVar:
+    ) -> scip.MatrixVariable:
         """Add a variable constrained to the value of the given SCIP expression."""
-        desired_shape = (
-            _squeeze_shape(_shape(expr)) if desired_shape is None else desired_shape
-        )
         self._aux_id += 1
         var = add_variable(
             self.model,
@@ -282,42 +199,9 @@ class Translater:
             lb=lb,
             ub=ub,
         )
-        if isinstance(var, scip.Variable):
-            self.model.addCons(var == expr)
-        else:
-            assert isinstance(var, scip.MatrixVariable)
-            self.model.addMatrixCons(var == expr)
+        assert isinstance(var, scip.MatrixVariable)
+        self.model.addMatrixCons(var == expr)
         return var
-
-    def apply_and_visit_elementwise(
-        self, fn: Callable[[cp.Expression], Any], expr: cp.Expression
-    ) -> Any:
-        """Apply fn to each element of `expr` and return the array of results."""
-
-        def visit(x: cp.Expression) -> Any:
-            return self.visit(fn(x))
-
-        vectorized_visitor = np.vectorize(visit, otypes=[np.object_])
-        subarray = to_subexpressions_array(expr, shape=expr.shape)
-        translated = vectorized_visitor(subarray)
-        return promote_array_to_scip_matrixapi(translated)
-
-    def star_apply_and_visit_elementwise(
-        self, fn: Callable[[Any], Any], *exprs: cp.Expression
-    ) -> Any:
-        """Apply fn across all given expressions and return the array of results.
-
-        The difference with `apply_and_visit_elementwise` is that fn is expected
-        to take multiple scalar arguments.
-        """
-
-        def visit(args: tuple[cp.Expression, ...]) -> Any:
-            return self.visit(fn(*args))
-
-        vectorized_visitor = np.vectorize(visit, otypes=[np.object_])
-        subarray = to_zipped_subexpressions_array(*exprs, shape=exprs[0].shape)
-        translated = vectorized_visitor(subarray)
-        return promote_array_to_scip_matrixapi(translated)
 
     def visit_abs(self, node: cp.abs) -> Any:
         (arg,) = node.args
@@ -353,25 +237,6 @@ class Translater:
     def visit_exp(self, node: cp.exp) -> AnyVar:
         (arg,) = node.args
         return scip.exp(self.visit(arg))
-
-    def _stack(
-        self,
-        node: Hstack | Vstack,
-        axis: Literal[0, 1],
-        name: Literal["hstack", "vstack"],
-    ) -> Any:
-        self._aux_id += 1
-        axis = min(axis, len(node.shape) - 1)
-        var = add_variable(self.model, shape=node.shape, name=f"{name}_{self._aux_id}")
-        start_idx = 0
-        for arg in node.args:
-            expr = self.visit(arg)
-            arg_shape = arg.shape
-            arg_shape += (1,) * (len(node.shape) - len(arg_shape))
-            indices = np.arange(start_idx, start_idx + arg.shape[axis])
-            self.model.addMatrixCons(var.take(indices, axis=axis) == expr)
-            start_idx += arg.shape[axis]
-        return var
 
     def visit_Hstack(self, node: Hstack) -> Any:
         args = node.args
@@ -520,7 +385,7 @@ class Translater:
                 self.model.addCons(cons, name=str(constraint.constr_id))
             elif isinstance(cons, scip.scip.MatrixExprCons):
                 self.model.addMatrixCons(cons, name=str(constraint.constr_id))
-            else:
+            else:  # pragma: no cover
                 msg = f"Unexpected constraint type: {type(cons)}"
                 raise TypeError(msg)
 


### PR DESCRIPTION
Bumps coverage from 85% to 92%. Most of the remaining missed lines are due to version-dependent code.

I also removed the fill_model function from the global interface as it was not exposed from Gurobi previously.