### PR TITLE
Write snapshots using CVXPY 1.7

### DIFF
--- a/tests/snapshots/gurobi/lp__attributes_00.txt
+++ b/tests/snapshots/gurobi/lp__attributes_00.txt
@@ -10,9 +10,8 @@ AFTER COMPILATION
 Minimize
   - C0
 Subject To
- R0: C0 <= 0
 Bounds
- C0 free
+ -infinity <= C0 <= 0
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__attributes_01.txt
+++ b/tests/snapshots/gurobi/lp__attributes_01.txt
@@ -10,9 +10,8 @@ AFTER COMPILATION
 Minimize
   - C0
 Subject To
- R0: C0 <= 0
 Bounds
- C0 free
+ -infinity <= C0 <= 0
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__attributes_04.txt
+++ b/tests/snapshots/gurobi/lp__attributes_04.txt
@@ -16,10 +16,9 @@ AFTER COMPILATION
 Minimize
   - C0 - C1 - C2
 Subject To
- R0: C0 <= 0
- R1: C1 <= 1
+ R0: C1 <= 1
 Bounds
- C0 free
+ -infinity <= C0 <= 0
  C1 free
 Binaries
  C2

--- a/tests/snapshots/gurobi/lp__genexpr_abs_08.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_08.txt
@@ -14,13 +14,9 @@ Subject To
  R1: - C1 + C3 <= 0
  R2: - C0 - C2 <= 0
  R3: - C1 - C3 <= 0
- R4: - C2 <= 0
- R5: - C3 <= 0
 Bounds
  C0 free
  C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_09.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_09.txt
@@ -15,17 +15,9 @@ Subject To
  R1: - C1 + C3 + C5 <= 0
  R2: - C0 - C2 - C4 <= 0
  R3: - C1 - C3 - C5 <= 0
- R4: - C2 <= 0
- R5: - C3 <= 0
- R6: - C4 <= 0
- R7: - C5 <= 0
 Bounds
  C0 free
  C1 free
- C2 free
- C3 free
- C4 free
- C5 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_10.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_10.txt
@@ -14,13 +14,9 @@ Subject To
  R1: - C1 + C3 <= 0
  R2: - C0 - C2 <= 0
  R3: - C1 - C3 <= 0
- R4: - C2 <= 0
- R5: - C3 <= 0
 Bounds
  C0 free
  C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_11.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_11.txt
@@ -14,13 +14,9 @@ Subject To
  R1: - C1 + C3 <= 0
  R2: - C0 - C2 <= 0
  R3: - C1 - C3 <= 0
- R4: - C2 <= 0
- R5: - C3 <= 0
 Bounds
  C0 free
  C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_12.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_12.txt
@@ -19,19 +19,11 @@ Subject To
  R5: - C3 + C7 <= 0
  R6: - C2 - C6 <= 0
  R7: - C3 - C7 <= 0
- R8: - C4 <= 0
- R9: - C5 <= 0
- R10: - C6 <= 0
- R11: - C7 <= 0
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
- C6 free
- C7 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_13.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_13.txt
@@ -14,13 +14,9 @@ Subject To
  R1: - C1 + C3 <= 0
  R2: - C0 - C2 <= 0
  R3: - C1 - C3 <= 0
- R4: - C2 <= 0
- R5: - C3 <= 0
 Bounds
  C0 free
  C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_14.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_14.txt
@@ -18,19 +18,11 @@ Subject To
  R5: - C1 - C5 <= 0
  R6: - C2 - C6 <= 0
  R7: - C3 - C7 <= 0
- R8: - C4 <= 0
- R9: - C5 <= 0
- R10: - C6 <= 0
- R11: - C7 <= 0
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
- C6 free
- C7 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_15.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_15.txt
@@ -19,27 +19,11 @@ Subject To
  R5: - C1 - C5 - C9 <= 0
  R6: - C2 - C6 - C10 <= 0
  R7: - C3 - C7 - C11 <= 0
- R8: - C4 <= 0
- R9: - C5 <= 0
- R10: - C6 <= 0
- R11: - C7 <= 0
- R12: - C8 <= 0
- R13: - C9 <= 0
- R14: - C10 <= 0
- R15: - C11 <= 0
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
- C6 free
- C7 free
- C8 free
- C9 free
- C10 free
- C11 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_16.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_16.txt
@@ -18,19 +18,11 @@ Subject To
  R5: - C1 - C5 <= 1
  R6: - C2 - C6 <= 1
  R7: - C3 - C7 <= 1
- R8: - C4 <= 0
- R9: - C5 <= 0
- R10: - C6 <= 0
- R11: - C7 <= 0
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
- C6 free
- C7 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_17.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_17.txt
@@ -19,19 +19,11 @@ Subject To
  R5: - C1 - C5 <= 0
  R6: - C2 - C6 <= 0
  R7: - C3 - C7 <= 0
- R8: - C4 <= 0
- R9: - C5 <= 0
- R10: - C6 <= 0
- R11: - C7 <= 0
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
- C6 free
- C7 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_18.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_18.txt
@@ -27,14 +27,6 @@ Subject To
  R13: - C5 - C13 <= 0
  R14: - C6 - C14 <= 0
  R15: - C7 - C15 <= 0
- R16: - C8 <= 0
- R17: - C9 <= 0
- R18: - C10 <= 0
- R19: - C11 <= 0
- R20: - C12 <= 0
- R21: - C13 <= 0
- R22: - C14 <= 0
- R23: - C15 <= 0
 Bounds
  C0 free
  C1 free
@@ -44,14 +36,6 @@ Bounds
  C5 free
  C6 free
  C7 free
- C8 free
- C9 free
- C10 free
- C11 free
- C12 free
- C13 free
- C14 free
- C15 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__genexpr_abs_19.txt
+++ b/tests/snapshots/gurobi/lp__genexpr_abs_19.txt
@@ -19,19 +19,11 @@ Subject To
  R5: - C1 - C5 <= 0
  R6: - C2 - C6 <= 0
  R7: - C3 - C7 <= 0
- R8: - C4 <= 0
- R9: - C5 <= 0
- R10: - C6 <= 0
- R11: - C7 <= 0
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
- C6 free
- C7 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_00.txt
+++ b/tests/snapshots/gurobi/lp__indexing_00.txt
@@ -8,13 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0
+  C0 + 0 C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_01.txt
+++ b/tests/snapshots/gurobi/lp__indexing_01.txt
@@ -8,13 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0
+  C0 + 0 C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_02.txt
+++ b/tests/snapshots/gurobi/lp__indexing_02.txt
@@ -8,17 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0
+  C0 + 0 C1 + 0 C2 + 0 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_03.txt
+++ b/tests/snapshots/gurobi/lp__indexing_03.txt
@@ -8,17 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C2
+  C0 + 0 C1 + C2 + 0 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_04.txt
+++ b/tests/snapshots/gurobi/lp__indexing_04.txt
@@ -8,17 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C2
+  C0 + 0 C1 + C2 + 0 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_05.txt
+++ b/tests/snapshots/gurobi/lp__indexing_05.txt
@@ -8,13 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0
+  C0 + 0 C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_06.txt
+++ b/tests/snapshots/gurobi/lp__indexing_06.txt
@@ -8,13 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0
+  C0 + 0 C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_07.txt
+++ b/tests/snapshots/gurobi/lp__indexing_07.txt
@@ -8,17 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C2
+  C0 + 0 C1 + C2 + 0 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_08.txt
+++ b/tests/snapshots/gurobi/lp__indexing_08.txt
@@ -8,17 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C2
+  C0 + 0 C1 + C2 + 0 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_09.txt
+++ b/tests/snapshots/gurobi/lp__indexing_09.txt
@@ -8,13 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0
+  C0 + 0 C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_10.txt
+++ b/tests/snapshots/gurobi/lp__indexing_10.txt
@@ -8,13 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0
+  C0 + 0 C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_11.txt
+++ b/tests/snapshots/gurobi/lp__indexing_11.txt
@@ -8,17 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C2
+  C0 + 0 C1 + C2 + 0 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_12.txt
+++ b/tests/snapshots/gurobi/lp__indexing_12.txt
@@ -8,17 +8,9 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C2
+  C0 + 0 C1 + C2 + 0 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_13.txt
+++ b/tests/snapshots/gurobi/lp__indexing_13.txt
@@ -10,11 +10,7 @@ AFTER COMPILATION
 Minimize
   C0 + C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_14.txt
+++ b/tests/snapshots/gurobi/lp__indexing_14.txt
@@ -10,11 +10,7 @@ AFTER COMPILATION
 Minimize
   C0 + C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__indexing_15.txt
+++ b/tests/snapshots/gurobi/lp__indexing_15.txt
@@ -10,15 +10,7 @@ AFTER COMPILATION
 Minimize
   C0 + C1 + C2 + C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__matrix_quadratic_constraints_00.txt
+++ b/tests/snapshots/gurobi/lp__matrix_quadratic_constraints_00.txt
@@ -11,27 +11,23 @@ AFTER COMPILATION
 Minimize
   - x_0 - x_1
 Subject To
- R0: - x_0 <= 0
- R1: - x_1 <= 0
- R2: x_2 <= 1
- R3: x_3 <= 1
- R4: - x_2 + soc_t_4 = 1
- R5: - x_2 + soc_x_5 = -1
- R6: - 2 x_0 + soc_x_6 = 0
- R7: - x_3 + soc_t_7 = 1
- R8: - x_3 + soc_x_8 = -1
- R9: - 2 x_1 + soc_x_9 = 0
- qc0: [ - soc_t_4 ^2 + soc_x_5 ^2 + soc_x_6 ^2 ] <= 0
- qc1: [ - soc_t_7 ^2 + soc_x_8 ^2 + soc_x_9 ^2 ] <= 0
+ R0: x_2 <= 1
+ R1: x_3 <= 1
+ R2: - x_2 + soc_t_2 = 1
+ R3: - x_2 + soc_x_3 = -1
+ R4: - 2 x_0 + soc_x_4 = 0
+ R5: - x_3 + soc_t_5 = 1
+ R6: - x_3 + soc_x_6 = -1
+ R7: - 2 x_1 + soc_x_7 = 0
+ qc0: [ - soc_t_2 ^2 + soc_x_3 ^2 + soc_x_4 ^2 ] <= 0
+ qc1: [ - soc_t_5 ^2 + soc_x_6 ^2 + soc_x_7 ^2 ] <= 0
 Bounds
- x_0 free
- x_1 free
  x_2 free
  x_3 free
- soc_x_5 free
+ soc_x_3 free
+ soc_x_4 free
  soc_x_6 free
- soc_x_8 free
- soc_x_9 free
+ soc_x_7 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__matrix_quadratic_constraints_01.txt
+++ b/tests/snapshots/gurobi/lp__matrix_quadratic_constraints_01.txt
@@ -11,47 +11,39 @@ AFTER COMPILATION
 Minimize
   - x_0 - x_1 - x_2 - x_3
 Subject To
- R0: - x_0 <= 0
- R1: - x_1 <= 0
- R2: - x_2 <= 0
- R3: - x_3 <= 0
- R4: x_4 <= 1
- R5: x_5 <= 1
- R6: x_6 <= 1
- R7: x_7 <= 1
- R8: - x_4 + soc_t_8 = 1
- R9: - x_4 + soc_x_9 = -1
- R10: - 2 x_0 + soc_x_10 = 0
- R11: - x_5 + soc_t_11 = 1
- R12: - x_5 + soc_x_12 = -1
- R13: - 2 x_1 + soc_x_13 = 0
- R14: - x_6 + soc_t_14 = 1
- R15: - x_6 + soc_x_15 = -1
- R16: - 2 x_2 + soc_x_16 = 0
- R17: - x_7 + soc_t_17 = 1
- R18: - x_7 + soc_x_18 = -1
- R19: - 2 x_3 + soc_x_19 = 0
- qc0: [ - soc_t_8 ^2 + soc_x_9 ^2 + soc_x_10 ^2 ] <= 0
- qc1: [ - soc_t_11 ^2 + soc_x_12 ^2 + soc_x_13 ^2 ] <= 0
- qc2: [ - soc_t_14 ^2 + soc_x_15 ^2 + soc_x_16 ^2 ] <= 0
- qc3: [ - soc_t_17 ^2 + soc_x_18 ^2 + soc_x_19 ^2 ] <= 0
+ R0: x_4 <= 1
+ R1: x_5 <= 1
+ R2: x_6 <= 1
+ R3: x_7 <= 1
+ R4: - x_4 + soc_t_4 = 1
+ R5: - x_4 + soc_x_5 = -1
+ R6: - 2 x_0 + soc_x_6 = 0
+ R7: - x_5 + soc_t_7 = 1
+ R8: - x_5 + soc_x_8 = -1
+ R9: - 2 x_1 + soc_x_9 = 0
+ R10: - x_6 + soc_t_10 = 1
+ R11: - x_6 + soc_x_11 = -1
+ R12: - 2 x_2 + soc_x_12 = 0
+ R13: - x_7 + soc_t_13 = 1
+ R14: - x_7 + soc_x_14 = -1
+ R15: - 2 x_3 + soc_x_15 = 0
+ qc0: [ - soc_t_4 ^2 + soc_x_5 ^2 + soc_x_6 ^2 ] <= 0
+ qc1: [ - soc_t_7 ^2 + soc_x_8 ^2 + soc_x_9 ^2 ] <= 0
+ qc2: [ - soc_t_10 ^2 + soc_x_11 ^2 + soc_x_12 ^2 ] <= 0
+ qc3: [ - soc_t_13 ^2 + soc_x_14 ^2 + soc_x_15 ^2 ] <= 0
 Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
  x_4 free
  x_5 free
  x_6 free
  x_7 free
+ soc_x_5 free
+ soc_x_6 free
+ soc_x_8 free
  soc_x_9 free
- soc_x_10 free
+ soc_x_11 free
  soc_x_12 free
- soc_x_13 free
+ soc_x_14 free
  soc_x_15 free
- soc_x_16 free
- soc_x_18 free
- soc_x_19 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__matrix_quadratic_constraints_02.txt
+++ b/tests/snapshots/gurobi/lp__matrix_quadratic_constraints_02.txt
@@ -12,21 +12,17 @@ AFTER COMPILATION
 Minimize
   - x_0 - x_1
 Subject To
- R0: - x_0 <= 0
- R1: - x_1 <= 0
- R2: 13.70820393249937 x_2 <= 1
- R3: - x_2 + soc_t_3 = 1
- R4: x_2 + soc_x_4 = 1
- R5: 0.2482165606933579 x_0 - 0.1534062710790964 x_1 + soc_x_5 = 0
- R6: - 1.051462224238267 x_0 - 1.70130161670408 x_1 + soc_x_6 = 0
- qc0: [ - soc_t_3 ^2 + soc_x_4 ^2 + soc_x_5 ^2 + soc_x_6 ^2 ] <= 0
+ R0: 13.70820393249937 x_2 <= 1
+ R1: - x_2 + soc_t_1 = 1
+ R2: x_2 + soc_x_2 = 1
+ R3: 0.2482165606933579 x_0 - 0.1534062710790964 x_1 + soc_x_3 = 0
+ R4: - 1.051462224238267 x_0 - 1.70130161670408 x_1 + soc_x_4 = 0
+ qc0: [ - soc_t_1 ^2 + soc_x_2 ^2 + soc_x_3 ^2 + soc_x_4 ^2 ] <= 0
 Bounds
- x_0 free
- x_1 free
  x_2 free
+ soc_x_2 free
+ soc_x_3 free
  soc_x_4 free
- soc_x_5 free
- soc_x_6 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__matrix_quadratic_constraints_03.txt
+++ b/tests/snapshots/gurobi/lp__matrix_quadratic_constraints_03.txt
@@ -12,21 +12,17 @@ AFTER COMPILATION
 Minimize
   - x_0 - x_1
 Subject To
- R0: - x_0 <= 0
- R1: - x_1 <= 0
- R2: x_2 <= 1
- R3: - x_2 + soc_t_3 = 1
- R4: x_2 + soc_x_4 = 1
- R5: - 4 x_0 - 6 x_1 + soc_x_5 = 0
- R6: - 2 x_1 + soc_x_6 = 0
- qc0: [ - soc_t_3 ^2 + soc_x_4 ^2 + soc_x_5 ^2 + soc_x_6 ^2 ] <= 0
+ R0: x_2 <= 1
+ R1: - x_2 + soc_t_1 = 1
+ R2: x_2 + soc_x_2 = 1
+ R3: - 4 x_0 - 6 x_1 + soc_x_3 = 0
+ R4: - 2 x_1 + soc_x_4 = 0
+ qc0: [ - soc_t_1 ^2 + soc_x_2 ^2 + soc_x_3 ^2 + soc_x_4 ^2 ] <= 0
 Bounds
- x_0 free
- x_1 free
  x_2 free
+ soc_x_2 free
+ soc_x_3 free
  soc_x_4 free
- soc_x_5 free
- soc_x_6 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__quad_form_02.txt
+++ b/tests/snapshots/gurobi/lp__quad_form_02.txt
@@ -1,6 +1,6 @@
 CVXPY
 Minimize
-  [1. 2.] @ A @ [1. 2.]
+  conj([1. 2.]) @ A @ [1. 2.]
 Subject To
 Bounds
  0.0 <= A
@@ -10,15 +10,7 @@ AFTER COMPILATION
 Minimize
   C0 + 2 C1 + 2 C2 + 4 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_00.txt
+++ b/tests/snapshots/gurobi/lp__simple_00.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_01.txt
+++ b/tests/snapshots/gurobi/lp__simple_01.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_02.txt
+++ b/tests/snapshots/gurobi/lp__simple_02.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   2 C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_03.txt
+++ b/tests/snapshots/gurobi/lp__simple_03.txt
@@ -11,11 +11,7 @@ AFTER COMPILATION
 Minimize
   C0 + C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_04.txt
+++ b/tests/snapshots/gurobi/lp__simple_04.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_05.txt
+++ b/tests/snapshots/gurobi/lp__simple_05.txt
@@ -12,12 +12,8 @@ AFTER COMPILATION
 Minimize
   C0 - C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: C1 <= 1
+ R0: C1 <= 1
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_06.txt
+++ b/tests/snapshots/gurobi/lp__simple_06.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   2 C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_07.txt
+++ b/tests/snapshots/gurobi/lp__simple_07.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   2 C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_08.txt
+++ b/tests/snapshots/gurobi/lp__simple_08.txt
@@ -11,11 +11,7 @@ AFTER COMPILATION
 Minimize
   2 C0 + C1
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_09.txt
+++ b/tests/snapshots/gurobi/lp__simple_09.txt
@@ -11,10 +11,8 @@ AFTER COMPILATION
 Minimize
   - C0
 Subject To
- R0: - C0 <= 0
- R1: C0 <= 1
+ R0: C0 <= 1
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_10.txt
+++ b/tests/snapshots/gurobi/lp__simple_10.txt
@@ -11,10 +11,8 @@ AFTER COMPILATION
 Minimize
   - C0
 Subject To
- R0: - C0 <= 0
- R1: C0 <= 1
+ R0: C0 <= 1
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_11.txt
+++ b/tests/snapshots/gurobi/lp__simple_11.txt
@@ -11,10 +11,8 @@ AFTER COMPILATION
 Minimize
   - C0
 Subject To
- R0: - C0 <= 0
- R1: C0 <= 1
+ R0: C0 <= 1
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_12.txt
+++ b/tests/snapshots/gurobi/lp__simple_12.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   0.5 C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_13.txt
+++ b/tests/snapshots/gurobi/lp__simple_13.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   0.5 C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_14.txt
+++ b/tests/snapshots/gurobi/lp__simple_14.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
  [ 2 C0 ^2 ] / 2 
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_15.txt
+++ b/tests/snapshots/gurobi/lp__simple_15.txt
@@ -11,10 +11,8 @@ Minimize
  [ 2 C0 ^2 ] / 2 
 Subject To
  R0: - C0 + C1 = 1
- R1: - C1 <= 0
 Bounds
  C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__simple_16.txt
+++ b/tests/snapshots/gurobi/lp__simple_16.txt
@@ -11,11 +11,7 @@ AFTER COMPILATION
 Minimize
  [ 2 C0 ^2 + 2 C1 ^2 ] / 2 
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
 Bounds
- C0 free
- C1 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_axis_00.txt
+++ b/tests/snapshots/gurobi/lp__sum_axis_00.txt
@@ -12,16 +12,8 @@ AFTER COMPILATION
 Minimize
   C0 + 2 C1 + 3 C2 + 4 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
- R4: - C0 - C1 - C2 - C3 <= -1
+ R0: - C0 - C1 - C2 - C3 <= -1
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_axis_01.txt
+++ b/tests/snapshots/gurobi/lp__sum_axis_01.txt
@@ -12,17 +12,9 @@ AFTER COMPILATION
 Minimize
   C0 + 2 C1 + 3 C2 + 4 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
- R4: - C0 - C1 <= -1
- R5: - C2 - C3 <= -1
+ R0: - C0 - C1 <= -1
+ R1: - C2 - C3 <= -1
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_axis_02.txt
+++ b/tests/snapshots/gurobi/lp__sum_axis_02.txt
@@ -12,17 +12,9 @@ AFTER COMPILATION
 Minimize
   C0 + 2 C1 + 3 C2 + 4 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
- R4: - C0 - C2 <= -1
- R5: - C1 - C3 <= -1
+ R0: - C0 - C2 <= -1
+ R1: - C1 - C3 <= -1
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_axis_03.txt
+++ b/tests/snapshots/gurobi/lp__sum_axis_03.txt
@@ -12,17 +12,9 @@ AFTER COMPILATION
 Minimize
   C0 + 2 C1 + 3 C2 + 4 C3
 Subject To
- R0: - C0 <= 0
- R1: - C1 <= 0
- R2: - C2 <= 0
- R3: - C3 <= 0
- R4: - C0 - C1 - C2 - C3 <= -1
- R5: <= -1
+ R0: - C0 - C1 - C2 - C3 <= -1
+ R1: <= -1
 Bounds
- C0 free
- C1 free
- C2 free
- C3 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_scalar_00.txt
+++ b/tests/snapshots/gurobi/lp__sum_scalar_00.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_scalar_01.txt
+++ b/tests/snapshots/gurobi/lp__sum_scalar_01.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_scalar_02.txt
+++ b/tests/snapshots/gurobi/lp__sum_scalar_02.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_scalar_03.txt
+++ b/tests/snapshots/gurobi/lp__sum_scalar_03.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_scalar_04.txt
+++ b/tests/snapshots/gurobi/lp__sum_scalar_04.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/gurobi/lp__sum_scalar_05.txt
+++ b/tests/snapshots/gurobi/lp__sum_scalar_05.txt
@@ -10,9 +10,7 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 <= 0
 Bounds
- C0 free
 End
 ----------------------------------------
 GUROBI

--- a/tests/snapshots/scip/lp__quad_form_02.txt
+++ b/tests/snapshots/scip/lp__quad_form_02.txt
@@ -1,6 +1,6 @@
 CVXPY
 Minimize
-  [1. 2.] @ A @ [1. 2.]
+  conj([1. 2.]) @ A @ [1. 2.]
 Subject To
 Bounds
  0.0 <= A

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -108,7 +108,7 @@ def test_lp(case: ProblemTestCase, snapshot: SnapshotFixture, tmp_path: Path) ->
         )
     )
 
-    if CVXPY_VERSION[:2] == (1, 6):
+    if CVXPY_VERSION[:2] == (1, 7):
         assert snapshot(f"{case.group}_{case.idx:02d}.txt") == output
     else:
         # don't update snapshots nor delete them


### PR DESCRIPTION
Nearly all changes come from the bounds that are now passed to Gurobi instead of adding constraints: https://github.com/cvxpy/cvxpy/pull/2740. This makes the output much cleaner.