### PR TITLE
Prevent insta from deleting all snapshots on startup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from pytest_insta import SnapshotSession
+
+
+class NoDeletionSnapshotSession(SnapshotSession):
+    """A snapshot session that does not delete snapshots."""
+
+    @property
+    def should_delete(self) -> bool:
+        return False
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    session.config._no_deletion_snapshot_session = NoDeletionSnapshotSession(session)  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -65,7 +65,7 @@ def snapshot(
 
     """
     path = SNAPSHOT_DIR / case.context.solver.lower() / "lp"
-    session: SnapshotSession = request.config._snapshot_session  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
+    session: SnapshotSession = request.config._no_deletion_snapshot_session  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
     with SnapshotFixture(session[path], session) as fixture:
         yield fixture
 


### PR DESCRIPTION
Since the snapshot overhaul in #145, insta would delete all snapshots at the start of the test session and then fail because they are missing. The solution was to delete all snapshots, and have insta create them from scratch.

It turns this is due to the way snapshots are now named. It gives the false impression that all tests in a group belong to the same test case, so when insta does not detect more than 1 test in the case, it assumes all the others are outdated and should be removed.

This is annoying because I like the naming scheme. Since we don't remove snapshots that often, I fix this problem by having insta not detect outdated snapshots. It means that to remove an outdated snapshots, we still need to delete all of them and rerun, but that doesn't happen too much.

The snapshot setup is getting quite customized. It makes me think it might be worth exploring other options that support customization, or maybe the latest version of insta already does :shrug: 