### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - env: "latest"
             python: "3.13"
           - env: "oldest"
-            python: "3.8"
+            python: "3.9"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ par with Gurobi.
   `cvxpy_translation`, and solver specific exceptions available from the solver
   submodules, `cvxpy_translation.gurobi` and `cvxpy_translation.scip`.
 
+- Support for EOL Python 3.8 has been dropped
+  ([#179](https://github.com/jonathanberthias/cvxpy-translation/pull/179)).
+
 ### New features
 
 - Support CVXPY 1.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,12 @@ license = "Apache-2.0"
 authors = [
   { name = "Jonathan Berthias", email = "jvberthias@gmail.com" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -36,7 +35,7 @@ dependencies = [
   # "cvxpy" must be available but we don't list it
   # as a dependency because cvxpy-base is sufficient
   "numpy>=1.23.0",
-  "scipy>=1.4.0",
+  "scipy>=1.5.4",
 ]
 
 [project.optional-dependencies]
@@ -58,8 +57,8 @@ description = "Base environment for other envs to inherit from"
 dependencies = [
   "pytest==7.4.4",
   "pytest-insta==0.2.0",
-  "pytest-xdist==3.6.1",
-  "pytest-cov==5.0.0",
+  "pytest-xdist==3.8.0",
+  "pytest-cov==6.2.1",
 ]
 installer = "uv"
 [tool.hatch.envs.default.scripts]
@@ -93,13 +92,13 @@ scripts = { update-snapshots = "hatch run latest:tests {args} tests/test_all.py:
 [tool.hatch.envs.oldest]
 description = "The oldest supported set of dependencies, for testing purposes"
 env-vars = { UV_RESOLUTION = "lowest-direct" }
-python = "3.8"
+python = "3.9"
 extra-dependencies = [
   # we have to set a version here since cvxpy is not listed as a dependency
   # we use cvxpy-base to avoid installing unnecessary dependencies
-  "cvxpy-base>=1.1.16",
+  "cvxpy-base==1.1.16",
   # bundled license is expired on older versions of gurobipy
-  "gurobipy>=11",
+  "gurobipy==11.*",
 ]
 features = ["gurobi", "scip"]
 
@@ -124,7 +123,7 @@ implicit_reexport = true
 
 [tool.pyright]
 typeCheckingMode = "basic"
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 
 [tool.hatch.envs.hatch-static-analysis]
 # https://hatch.pypa.io/latest/config/static-analysis/
@@ -181,7 +180,7 @@ skip-magic-trailing-comma = true
 
 [tool.pytest.ini_options]
 addopts = ["-ra", "--strict-config", "--strict-markers"]
-minversion = "6"
+minversion = "7"
 pythonpath = "tests"
 testpaths = ["tests"]
 xfail_strict = true
@@ -195,7 +194,6 @@ omit = [
 ]
 [tool.coverage.report]
 exclude_also = [
-  "if TYPE_CHECKING:",
   "@overload",
 ]
 show_missing = true

--- a/src/cvxpy_translation/gurobi/interface.py
+++ b/src/cvxpy_translation/gurobi/interface.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from contextlib import suppress
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import Iterator
 from typing import Union
 
 import cvxpy as cp
@@ -24,12 +22,14 @@ from cvxpy_translation.gurobi.translation import Translater
 from cvxpy_translation.utils import Timer
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from cvxpy.constraints.constraint import Constraint
     from typing_extensions import TypeAlias
 
 AnyVar: TypeAlias = Union[gp.Var, gp.MVar]
 Param: TypeAlias = Union[str, float]
-ParamDict: TypeAlias = Dict[str, Param]
+ParamDict: TypeAlias = dict[str, Param]
 
 # Default name for the solver when registering it with CVXPY.
 GUROBI_TRANSLATION: str = "GUROBI_TRANSLATION"

--- a/src/cvxpy_translation/gurobi/translation.py
+++ b/src/cvxpy_translation/gurobi/translation.py
@@ -6,8 +6,6 @@ from math import prod
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import Iterator
 from typing import Union
 from typing import overload
 
@@ -22,6 +20,8 @@ from cvxpy_translation.exceptions import UnsupportedError
 from cvxpy_translation.exceptions import UnsupportedExpressionError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from cvxpy.atoms.affine.add_expr import AddExpression
     from cvxpy.atoms.affine.binary_operators import DivExpression
     from cvxpy.atoms.affine.binary_operators import MulExpression
@@ -46,7 +46,7 @@ GUROBI_MAJOR = GUROBIPY_VERSION[0]
 
 AnyVar: TypeAlias = Union[gp.Var, gp.MVar]
 Param: TypeAlias = Union[str, float]
-ParamDict: TypeAlias = Dict[str, Param]
+ParamDict: TypeAlias = dict[str, Param]
 
 
 class InvalidPowerError(UnsupportedExpressionError):

--- a/src/cvxpy_translation/interface.py
+++ b/src/cvxpy_translation/interface.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
 
 import cvxpy as cp
 
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 
 
 Param: TypeAlias = Any
-ParamDict: TypeAlias = Dict[str, Param]
+ParamDict: TypeAlias = dict[str, Param]
 
 
 def solve(problem: cp.Problem, solver: str, **params: Param) -> float:

--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from contextlib import suppress
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import Iterator
 from typing import Union
 
 import cvxpy as cp
@@ -24,12 +22,14 @@ from cvxpy_translation.scip.translation import Translater
 from cvxpy_translation.utils import Timer
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from cvxpy.constraints.constraint import Constraint
     from typing_extensions import TypeAlias
 
 AnyVar: TypeAlias = Union[scip.Variable, scip.MatrixVariable]
 Param: TypeAlias = Union[str, float]
-ParamDict: TypeAlias = Dict[str, Param]
+ParamDict: TypeAlias = dict[str, Param]
 
 # Default name for the solver when registering it with CVXPY.
 SCIP_TRANSLATION: str = "SCIP_TRANSLATION"

--- a/src/cvxpy_translation/scip/translation.py
+++ b/src/cvxpy_translation/scip/translation.py
@@ -5,7 +5,6 @@ from functools import reduce
 from math import prod
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
 from typing import Literal
 from typing import Union
 from typing import overload
@@ -44,7 +43,7 @@ if TYPE_CHECKING:
 
 AnyVar: TypeAlias = Union[scip.Variable, scip.MatrixVariable]
 Param: TypeAlias = Union[str, float]
-ParamDict: TypeAlias = Dict[str, Param]
+ParamDict: TypeAlias = dict[str, Param]
 
 
 class InvalidPowerError(UnsupportedExpressionError):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Final
-from typing import Generator
 from unittest.mock import patch
 
 import cvxpy as cp
@@ -25,6 +24,8 @@ from test_problems import ProblemTestCase
 from test_problems import all_valid_problems
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from cvxpy.reductions.solution import Solution
     from pytest_insta.session import SnapshotSession
 

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from dataclasses import replace
 from functools import partial
 from functools import wraps
+from typing import TYPE_CHECKING
 from typing import Callable
-from typing import Generator
 from typing import Literal
 
 import cvxpy as cp
@@ -14,6 +14,9 @@ import scipy.sparse as sp
 
 from cvxpy_translation import CVXPY_VERSION
 from cvxpy_translation.gurobi.translation import GUROBI_MAJOR
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
It's about time, even though the only gain we get is newer test dependencies...