### PR TITLE
Remove auxilliary variable when reshaping parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ par with Gurobi.
 - Scalar quadratic forms were incorrectly handled in CVXPY versions before
   1.4.0, this now works as expected
   ([#146](https://github.com/jonathanberthias/cvxpy-translation/pull/146))
+- An unnecessary variable was generated when parameters appeared in a
+  `cp.reshape` expression
+  ([#180](https://github.com/jonathanberthias/cvxpy-translation/pull/180))
 
 ## [1.2.0] - 2025-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ par with Gurobi.
   ([#146](https://github.com/jonathanberthias/cvxpy-translation/pull/146))
 - An unnecessary variable was generated when parameters appeared in a
   `cp.reshape` expression
-  ([#180](https://github.com/jonathanberthias/cvxpy-translation/pull/180))
+  ([#182](https://github.com/jonathanberthias/cvxpy-translation/pull/182))
 
 ## [1.2.0] - 2025-03-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ extra-dependencies = [
   "numpy==2.3.2",
   "scipy==1.16.1",
 ]
-scripts = { update-snapshots = "hatch run latest:tests {args} tests/test_all.py::test_lp" }
+scripts = { update-snapshots = "hatch run latest:tests --insta update {args} tests/test_all.py::test_lp" }
 
 [tool.hatch.envs.oldest]
 description = "The oldest supported set of dependencies, for testing purposes"

--- a/src/cvxpy_translation/scip/translation.py
+++ b/src/cvxpy_translation/scip/translation.py
@@ -430,12 +430,9 @@ class Translater:
         """
         (x,) = node.args
         target_shape = node.shape
-        if isinstance(x, cp.Constant):
-            try:
-                return x.value.reshape(target_shape)
-            except AttributeError:
-                return np.reshape(x, target_shape)
         expr = self.visit(x)
+        if isinstance(expr, (int, float)):
+            return np.reshape(expr, target_shape)
         if isinstance(expr, scip.Expr):
             if target_shape == ():
                 return expr
@@ -444,18 +441,7 @@ class Translater:
             assert isinstance(expr, scip.MatrixExpr)
             assert _is_scalar(expr)
             return expr.item()
-        elif not isinstance(expr, scip.MatrixExpr):
-            expr_shape = _shape(expr)
-            # Force creation of a MatrixVariable even if the shape is scalar
-            if expr_shape == ():
-                expr_shape = (1,)
-            expr = self.make_auxilliary_variable_for(
-                expr, "reshape", desired_shape=expr_shape
-            )
-            assert isinstance(expr, scip.MatrixVariable)
-        reshaped = expr.reshape(target_shape)
-        assert reshaped.shape == target_shape
-        return reshaped
+        return expr.reshape(target_shape)
 
     def visit_special_index(self, node: special_index) -> Any:
         return self.visit(node.args[0])[node.key]

--- a/tests/snapshots/gurobi/lp__reshape_30.txt
+++ b/tests/snapshots/gurobi/lp__reshape_30.txt
@@ -15,9 +15,8 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  x + reshape_1[0]
+  x + Constant
 Subject To
- R0: reshape_1[0] = 1
 Bounds
- reshape_1[0] free
+ Constant = 1
 End

--- a/tests/snapshots/gurobi/lp__reshape_30.txt
+++ b/tests/snapshots/gurobi/lp__reshape_30.txt
@@ -1,0 +1,23 @@
+CVXPY
+Minimize
+  x + reshape(param1, (1,), F)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+Bounds
+End
+----------------------------------------
+GUROBI
+Minimize
+  x + reshape_1[0]
+Subject To
+ R0: reshape_1[0] = 1
+Bounds
+ reshape_1[0] free
+End

--- a/tests/snapshots/gurobi/lp__reshape_31.txt
+++ b/tests/snapshots/gurobi/lp__reshape_31.txt
@@ -1,6 +1,6 @@
 CVXPY
 Minimize
-  x + reshape(param1, (1,), F)
+  x + reshape(2.5, (1,), F)
 Subject To
 Bounds
  0.0 <= x
@@ -8,16 +8,15 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
+  C0
+Subject To
 Bounds
- x_0 free
 End
 ----------------------------------------
-SCIP
+GUROBI
 Minimize
- Obj: +1 x +1
-Subject to
+  x + 2.5 Constant
+Subject To
 Bounds
+ Constant = 1
 End

--- a/tests/snapshots/scip/lp__reshape_30.txt
+++ b/tests/snapshots/scip/lp__reshape_30.txt
@@ -1,0 +1,25 @@
+CVXPY
+Minimize
+  x + reshape(param1, (1,), F)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ Obj: +1 x_0
+Subject to
+ c1: -1 x_0 <= +0
+Bounds
+ x_0 free
+End
+----------------------------------------
+SCIP
+Minimize
+ Obj: +1 x +1 reshape_1_0
+Subject to
+ c1: +1 reshape_1_0 = +1
+Bounds
+ reshape_1_0 free
+End

--- a/tests/snapshots/scip/lp__reshape_31.txt
+++ b/tests/snapshots/scip/lp__reshape_31.txt
@@ -1,6 +1,6 @@
 CVXPY
 Minimize
-  x + reshape(param1, (1,), F)
+  x + reshape(2.5, (1,), F)
 Subject To
 Bounds
  0.0 <= x
@@ -17,7 +17,7 @@ End
 ----------------------------------------
 SCIP
 Minimize
- Obj: +1 x +1
+ Obj: +1 x +2.5
 Subject to
 Bounds
 End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -692,8 +692,10 @@ def reshape() -> Generator[cp.Problem]:
     reset_id_counter()
     p = cp.Parameter()
     p.value = 1
+    c = cp.Constant(2.5)
     x = cp.Variable(name="x", nonneg=True)
     yield cp.Problem(cp.Minimize(x + cp.reshape(p, (1,), order="F")))
+    yield cp.Problem(cp.Minimize(x + cp.reshape(c, (1,), order="F")))
 
 
 def _stack(stack_name: Literal["vstack", "hstack"]) -> Generator[cp.Problem]:

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -689,6 +689,12 @@ def reshape() -> Generator[cp.Problem]:
     )
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.vec(x) <= np.arange(4)])
 
+    reset_id_counter()
+    p = cp.Parameter()
+    p.value = 1
+    x = cp.Variable(name="x", nonneg=True)
+    yield cp.Problem(cp.Minimize(x + cp.reshape(p, (1,), order="F")))
+
 
 def _stack(stack_name: Literal["vstack", "hstack"]) -> Generator[cp.Problem]:
     stack = getattr(cp, stack_name)


### PR DESCRIPTION
This was due to the reshape translation checking for constants instead of working with any constant value, such as parameters.