### PR TITLE
Error on unsupported leaf attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,22 +19,23 @@ par with Gurobi.
   `register_translation_solver` now require a `solver` argument that must be the
   solver name from CVXPY. The previous functions for Gurobi are still available
   by importing from `cvxpy_translation.gurobi`.
-
 - Exceptions are now split between general exceptions defined in the top-level
   `cvxpy_translation`, and solver specific exceptions available from the solver
   submodules, `cvxpy_translation.gurobi` and `cvxpy_translation.scip`.
-
+- Unhandled attributes set on `Variable` and `Parameter` will now raise an error
+  instead of being silently ignored
+  ([#185](https://github.com/jonathanberthias/cvxpy-translation/pull/185))
 - Support for EOL Python 3.8 has been dropped
   ([#179](https://github.com/jonathanberthias/cvxpy-translation/pull/179)).
 
 ### New features
 
 - Support variable bounds
-  ([#183](https://github.com/jonathanberthias/cvxpy-translation/pull/183))
+  ([#184](https://github.com/jonathanberthias/cvxpy-translation/pull/184))
 - Support CVXPY 1.7
   ([#165](https://github.com/jonathanberthias/cvxpy-translation/pull/165))
-- Add support for `cp.conj` which is used internally by `cp.quad_form` in CVXPY
-  1.7 ([#165](https://github.com/jonathanberthias/cvxpy-translation/pull/165))
+- Add support for `cp.conj` which is used by `cp.quad_form` in CVXPY 1.7
+  ([#165](https://github.com/jonathanberthias/cvxpy-translation/pull/165))
 
 ### Bug fixes
 

--- a/src/cvxpy_translation/exceptions.py
+++ b/src/cvxpy_translation/exceptions.py
@@ -1,12 +1,22 @@
-from cvxpy.utilities.canonical import Canonical
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+
+if TYPE_CHECKING:
+    from cvxpy.expressions.leaf import Leaf
+    from cvxpy.utilities.canonical import Canonical
 
 
 class UnsupportedError(ValueError):
     msg_template = "Unsupported CVXPY node: {node}"
 
-    def __init__(self, node: Canonical) -> None:
-        super().__init__(self.msg_template.format(node=node, klass=type(node)))
+    def __init__(self, node: Canonical, **kwargs: Any) -> None:
+        super().__init__(
+            self.msg_template.format(node=node, klass=type(node), **kwargs)
+        )
         self.node = node
+        self.kwargs = kwargs
 
 
 class UnsupportedConstraintError(UnsupportedError):
@@ -15,6 +25,14 @@ class UnsupportedConstraintError(UnsupportedError):
 
 class UnsupportedExpressionError(UnsupportedError):
     msg_template = "Unsupported CVXPY expression: {node} ({klass})"
+
+
+class UnsupportedAttributesError(UnsupportedExpressionError):
+    msg_template = "Unsupported attributes for {node}: {attributes}"
+
+    def __init__(self, leaf: Leaf, attributes: set[str]) -> None:
+        super().__init__(leaf, attributes=list(attributes))
+        self.unhandled = attributes
 
 
 class InvalidParameterError(UnsupportedExpressionError):

--- a/src/cvxpy_translation/exceptions.py
+++ b/src/cvxpy_translation/exceptions.py
@@ -31,7 +31,7 @@ class UnsupportedAttributesError(UnsupportedExpressionError):
     msg_template = "Unsupported attributes for {node}: {attributes}"
 
     def __init__(self, leaf: Leaf, attributes: set[str]) -> None:
-        super().__init__(leaf, attributes=list(attributes))
+        super().__init__(leaf, attributes=sorted(attributes))
         self.unhandled = attributes
 
 

--- a/src/cvxpy_translation/gurobi/translation.py
+++ b/src/cvxpy_translation/gurobi/translation.py
@@ -14,6 +14,7 @@ import gurobipy as gp
 import numpy as np
 import numpy.typing as npt
 import scipy.sparse as sp
+from cvxpy.constraints.constraint import Constraint
 
 from cvxpy_translation import CVXPY_VERSION
 from cvxpy_translation.exceptions import InvalidParameterError
@@ -211,7 +212,7 @@ class Translater:
         if visitor is not None:
             return visitor(node)
 
-        if isinstance(node, cp.Constraint):
+        if isinstance(node, Constraint):
             raise UnsupportedConstraintError(node)
         if isinstance(node, cp.Expression):
             raise UnsupportedExpressionError(node)

--- a/src/cvxpy_translation/scip/translation.py
+++ b/src/cvxpy_translation/scip/translation.py
@@ -14,6 +14,7 @@ import numpy as np
 import numpy.typing as npt
 import pyscipopt as scip
 import scipy.sparse as sp
+from cvxpy.constraints.constraint import Constraint
 from pyscipopt.recipes.nonlinear import set_nonlinear_objective
 
 from cvxpy_translation import CVXPY_VERSION
@@ -180,7 +181,7 @@ class Translater:
         if visitor is not None:
             return visitor(node)
 
-        if isinstance(node, cp.Constraint):
+        if isinstance(node, Constraint):
             raise UnsupportedConstraintError(node)
         if isinstance(node, cp.Expression):
             raise UnsupportedExpressionError(node)

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -47,8 +47,9 @@ def test_failing_atoms(
 ) -> None:
     if invalid_case.skip_reason:
         pytest.skip(invalid_case.skip_reason)
-    with pytest.raises(cvxpy_translation.UnsupportedExpressionError):
-        invalid_case_translater.visit(invalid_case.problem.objective.expr)
+    with pytest.raises(cvxpy_translation.UnsupportedExpressionError) as exc:
+        invalid_case_translater.visit(invalid_case.problem)
+    assert type(exc.value) is not cvxpy_translation.UnsupportedExpressionError
 
 
 def test_parameter(translater: Any) -> None:

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -861,6 +861,33 @@ def invalid_expressions() -> Generator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.norm(v, 0.5)))
 
 
+@group_cases("unsupported_attributes", invalid_reason="unsupported attributes")
+def unsupported_attributes() -> Generator[cp.Problem]:
+    complex_ = cp.Variable(name="x", complex=True)
+    yield cp.Problem(cp.Minimize(cp.real(complex_)))
+
+    psd = cp.Variable((2, 2), name="x", PSD=True)
+    yield cp.Problem(cp.Minimize(cp.sum(psd)))
+
+    nsd = cp.Variable((2, 2), name="x", NSD=True)
+    yield cp.Problem(cp.Minimize(cp.sum(nsd)))
+
+    symmetric = cp.Variable((2, 2), name="x", symmetric=True)
+    yield cp.Problem(cp.Minimize(cp.sum(symmetric)))
+
+    imag = cp.Variable(name="x", imag=True)
+    yield cp.Problem(cp.Minimize(cp.real(imag)))
+
+    diag = cp.Variable((2, 2), name="x", diag=True)
+    yield cp.Problem(cp.Minimize(cp.sum(diag)))
+
+    hermitian = cp.Variable((2, 2), name="x", hermitian=True)
+    yield cp.Problem(cp.Minimize(cp.real(cp.sum(hermitian))))
+
+    sparsity = cp.Variable(4, name="x", sparsity=[[0]])
+    yield cp.Problem(cp.Minimize(cp.sum(sparsity)))
+
+
 @skipif(
     lambda case: case.context.solver == cp.GUROBI,
     "hstack variant not supported by gurobipy",

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -863,28 +863,30 @@ def invalid_expressions() -> Generator[cp.Problem]:
 
 @group_cases("unsupported_attributes", invalid_reason="unsupported attributes")
 def unsupported_attributes() -> Generator[cp.Problem]:
-    complex_ = cp.Variable(name="x", complex=True)
-    yield cp.Problem(cp.Minimize(cp.real(complex_)))
+    x = cp.Variable(name="x", nonneg=True)
 
-    psd = cp.Variable((2, 2), name="x", PSD=True)
+    complex_ = cp.Variable(complex=True)
+    yield cp.Problem(cp.Minimize(x), [complex_ == 1])
+
+    psd = cp.Variable((2, 2), PSD=True)
     yield cp.Problem(cp.Minimize(cp.sum(psd)))
 
-    nsd = cp.Variable((2, 2), name="x", NSD=True)
+    nsd = cp.Variable((2, 2), NSD=True)
     yield cp.Problem(cp.Minimize(cp.sum(nsd)))
 
-    symmetric = cp.Variable((2, 2), name="x", symmetric=True)
+    symmetric = cp.Variable((2, 2), symmetric=True)
     yield cp.Problem(cp.Minimize(cp.sum(symmetric)))
 
-    imag = cp.Variable(name="x", imag=True)
-    yield cp.Problem(cp.Minimize(cp.real(imag)))
+    imag = cp.Variable(imag=True)
+    yield cp.Problem(cp.Minimize(x), [imag == 1j])
 
-    diag = cp.Variable((2, 2), name="x", diag=True)
+    diag = cp.Variable((2, 2), diag=True)
     yield cp.Problem(cp.Minimize(cp.sum(diag)))
 
-    hermitian = cp.Variable((2, 2), name="x", hermitian=True)
-    yield cp.Problem(cp.Minimize(cp.real(cp.sum(hermitian))))
+    hermitian = cp.Variable((2, 2), hermitian=True)
+    yield cp.Problem(cp.Minimize(x), [cp.sum(hermitian) == 1])
 
-    sparsity = cp.Variable(4, name="x", sparsity=[[0]])
+    sparsity = cp.Variable(4, sparsity=[[0]])
     yield cp.Problem(cp.Minimize(cp.sum(sparsity)))
 
 


### PR DESCRIPTION
Closes #130 
Closes #168 

We only allow a limited set of attributes and error on anything else.

The tests are a little subtle because we have to avoid using unsupported atoms to ensure we hit the attribute-related errors.