### PR TITLE
Error on partially boolean or integer variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ par with Gurobi.
   submodules, `cvxpy_translation.gurobi` and `cvxpy_translation.scip`.
 - Unhandled attributes set on `Variable` and `Parameter` will now raise an error
   instead of being silently ignored
-  ([#185](https://github.com/jonathanberthias/cvxpy-translation/pull/185))
+  ([#185](https://github.com/jonathanberthias/cvxpy-translation/pull/185),
+  [#190](https://github.com/jonathanberthias/cvxpy-translation/pull/190))
 - Support for EOL Python 3.8 has been dropped
   ([#179](https://github.com/jonathanberthias/cvxpy-translation/pull/179)).
 

--- a/src/cvxpy_translation/exceptions.py
+++ b/src/cvxpy_translation/exceptions.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
+from cvxpy.expressions.leaf import Leaf
+
 if TYPE_CHECKING:
     from cvxpy.expressions.leaf import Leaf
     from cvxpy.utilities.canonical import Canonical
@@ -33,6 +35,15 @@ class UnsupportedAttributesError(UnsupportedExpressionError):
     def __init__(self, leaf: Leaf, attributes: set[str]) -> None:
         super().__init__(leaf, attributes=sorted(attributes))
         self.unhandled = attributes
+
+
+class UnsupportedPartialAttributesError(UnsupportedExpressionError):
+    msg_template = (
+        "Unsupported partial attribute {attribute} for {node}. Split the leaf instead."
+    )
+
+    def __init__(self, leaf: Leaf, attribute: str) -> None:
+        super().__init__(leaf, attribute=attribute)
 
 
 class InvalidParameterError(UnsupportedExpressionError):

--- a/src/cvxpy_translation/exceptions.py
+++ b/src/cvxpy_translation/exceptions.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
-from cvxpy.expressions.leaf import Leaf
-
 if TYPE_CHECKING:
     from cvxpy.expressions.leaf import Leaf
     from cvxpy.utilities.canonical import Canonical

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -889,6 +889,18 @@ def unsupported_attributes() -> Generator[cp.Problem]:
     sparsity = cp.Variable(4, sparsity=[[0]])
     yield cp.Problem(cp.Minimize(cp.sum(sparsity)))
 
+    partial_integer1 = cp.Variable(3, integer=[1])
+    yield cp.Problem(cp.Minimize(cp.sum(partial_integer1)))
+
+    partial_integer2 = cp.Variable(3, integer=[True, False, True])
+    yield cp.Problem(cp.Minimize(cp.sum(partial_integer2)))
+
+    partial_boolean1 = cp.Variable(3, boolean=[1])
+    yield cp.Problem(cp.Minimize(cp.sum(partial_boolean1)))
+
+    partial_boolean2 = cp.Variable(3, boolean=[True, False, True])
+    yield cp.Problem(cp.Minimize(cp.sum(partial_boolean2)))
+
 
 @skipif(
     lambda case: case.context.solver == cp.GUROBI,


### PR DESCRIPTION
Variables can be set as boolean or integer only on some indexes. This is not supported by Gurobi nor SCIP, so when we detect this case, we should error out.