### PR TITLE
Fix SCIP when user limit is hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fix translation of constant objective terms for both SCIP and Gurobi
   ([#197](https://github.com/jonathanberthias/cvxpy-translation/pull/197))
+- Fix backfilling for SCIP when presolve removes constraints
+  ([#201](https://github.com/jonathanberthias/cvxpy-translation/pull/201))
+- Fix backfilling for SCIP when a user limit is hit before any solution is found
+  ([#202](https://github.com/jonathanberthias/cvxpy-translation/pull/202))
 
 ## [2.0.0] - 2025-08-23
 

--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -6,7 +6,6 @@ from typing import Union
 
 import cvxpy as cp
 import cvxpy.settings as cp_settings
-import cvxpy.settings as s
 import numpy as np
 import numpy.typing as npt
 import pyscipopt as scip
@@ -102,7 +101,7 @@ def backfill_problem(
     # so we lie about the status to be sure the processing is still done
     original_status = solution.status
     if model.getNSols() == 0:
-        solution.status = s.INFEASIBLE
+        solution.status = cp_settings.INFEASIBLE
 
     problem.unpack(solution)
     solution.status = original_status
@@ -137,7 +136,11 @@ def extract_solution_from_model(model: scip.Model, problem: cp.Problem) -> Solut
     if model.getNSols() == 0:
         # Make status more accurate - user limit statuses are like:
         # timelimit, nodelimit, bestsollimit, etc.
-        status = s.USER_LIMIT if model.getStatus().endswith("limit") else s.SOLVER_ERROR
+        status = (
+            cp_settings.USER_LIMIT
+            if model.getStatus().endswith("limit")
+            else cp_settings.SOLVER_ERROR
+        )
         if CVXPY_VERSION >= (1, 2, 0):
             # attr was added in https://github.com/cvxpy/cvxpy/pull/1270
             return failure_solution(status, attr)

--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -130,17 +130,6 @@ class UnavailableDualError(ValueError):
     pass
 
 
-LIMIT_STATUSES = {
-    "timelimit",
-    "nodelimit",
-    "totalnodelimit",
-    "stallnodelimit",
-    "memlimit",
-    "sollimit",
-    "bestsollimit",
-}
-
-
 def extract_solution_from_model(model: scip.Model, problem: cp.Problem) -> Solution:
     attr = {
         cp_settings.EXTRA_STATS: model,
@@ -149,8 +138,9 @@ def extract_solution_from_model(model: scip.Model, problem: cp.Problem) -> Solut
     }
     status = scip_conif.STATUS_MAP[model.getStatus()]
     if model.getNSols() == 0:
-        # Make status more accurate
-        status = s.USER_LIMIT if model.getStatus() in LIMIT_STATUSES else s.SOLVER_ERROR
+        # Make status more accurate - user limit statuses are like:
+        # timelimit, nodelimit, bestsollimit, etc.
+        status = s.USER_LIMIT if model.getStatus().endswith("limit") else s.SOLVER_ERROR
         if CVXPY_VERSION >= (1, 2, 0):
             # attr was added in https://github.com/cvxpy/cvxpy/pull/1270
             return failure_solution(status, attr)

--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -89,9 +89,6 @@ def set_params(model: scip.Model, params: ParamDict) -> None:
         model.setParam(key, param)
 
 
-CP_STATUS_WITH_SOLUTION = {cp.OPTIMAL, cp.OPTIMAL_INACCURATE}
-
-
 def backfill_problem(
     problem: cp.Problem,
     model: scip.Model,

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,4 +1,6 @@
 import cvxpy as cp
+import numpy as np
+import pytest
 
 from cvxpy_translation import backfill_problem
 from cvxpy_translation import build_model
@@ -21,3 +23,30 @@ def test_empty_presolved_model_grb():
     model = build_model(problem, cp.GUROBI)
     model.optimize()
     backfill_problem(problem, model)
+
+
+@pytest.mark.parametrize(
+    ("param", "value", "status"),
+    [
+        ("limits/time", 0, "timelimit"),
+        ("limits/nodes", 0, "nodelimit"),
+        ("limits/totalnodes", 0, "totalnodelimit"),
+        ("limits/stallnodes", 0, "stallnodelimit"),
+        ("limits/memory", 0, "memlimit"),
+        ("limits/solutions", 0, "sollimit"),
+        ("limits/bestsol", 0, "bestsollimit"),
+    ],
+)
+def test_user_limit_scip(param: str, value: int, status: str):
+    """If the user limit is reached, the problem should still be backfilled."""
+    x = cp.Variable(50, boolean=True)
+    # some random non-trivial problem
+    problem = cp.Problem(
+        cp.Minimize(cp.sum(x**2 + cp.log1p(x))), [x @ np.arange(x.size) == 13]
+    )
+    model = build_model(problem, cp.SCIP)
+    model.setParam(param, value)
+    model.optimize()
+    assert model.getStatus() == status
+    backfill_problem(problem, model)
+    assert problem.status == cp.USER_LIMIT


### PR DESCRIPTION
We have to work around the status mapping on CVXPY to ensure we assign the correct status based on the SCIP model, and then we have to trick CVXPY into thinking it's another status.
A real mess, hopefully the tests will detect if anything changes.

Fixes #199.